### PR TITLE
fix segfault from canonicalize_file_name() when _GNU_SOURCE is not defined

### DIFF
--- a/os/Linux.c
+++ b/os/Linux.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE     /* for canonicalize_file_name */
 #include <ctype.h>      /* is_digit */
 #include <dirent.h>     /* opendir, readdir_r */
 #include <fcntl.h>


### PR DESCRIPTION
see https://github.com/jackdoe/random/blob/master/broken/README.txt

```
use strict;
use Proc::ProcessTable;
my $x = "a" x 2000;
my @a = ();
for my $n(1..1100_000) {
    push @a,$x;
}
my $p = Proc::ProcessTable->new( 'cache_ttys' => 1 );
my $table = $p->table;
```

i didnt create a new test case for that, not because of my failure to understand the actual problem, and the fact that it has to do 1_100_000 million things in order to trigger the segfault.

segfault is:

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff6a15e3c in _IO_vfprintf_internal (s=<value optimized out>, format=<value optimized out>, ap=<value optimized out>) at vfprintf.c:1641
1641          process_string_arg (((struct printf_spec *) NULL));
(gdb) bt
#0  0x00007ffff6a15e3c in _IO_vfprintf_internal (s=<value optimized out>, format=<value optimized out>, ap=<value optimized out>) at vfprintf.c:1641
#1  0x00007ffff6a3d9c7 in _IO_obstack_vprintf (obstack=0x7fffffffdeb0, format=0x7ffff00b4ce6 "%s", args=0x7fffffffdb50) at obprintf.c:171
#2  0x00007ffff6a3dab8 in _IO_obstack_printf (obstack=<value optimized out>, format=<value optimized out>) at obprintf.c:188
#3  0x00007ffff00b2393 in eval_link () from /usr/local/perl/5.18.2/site/lib/auto/Proc/ProcessTable/ProcessTable.so
#4  0x00007ffff00b2eb4 in OS_get_table () from /usr/local/perl/5.18.2/site/lib/auto/Proc/ProcessTable/ProcessTable.so
#5  0x00007ffff00b422f in XS_Proc__ProcessTable_table () from /usr/local/perl/5.18.2/site/lib/auto/Proc/ProcessTable/ProcessTable.so
#6  0x00007ffff7b11ce5 in Perl_pp_entersub () from /usr/local/perl/5.18.2/lib/CORE/libperl.so
#7  0x00007ffff7b10313 in Perl_runops_standard () from /usr/local/perl/5.18.2/lib/CORE/libperl.so
#8  0x00007ffff7aa9c4c in perl_run () from /usr/local/perl/5.18.2/lib/CORE/libperl.so
#9  0x0000000000400ddc in main ()
```

similar dump listed in: https://rt.cpan.org/Public/Bug/Display.html?id=99163

which is just canonicalize_file_name returning bogous address (valgrind's memcheck says not on stack, not malloced and not recently freed)
