### PR TITLE
Enable 'use warnings'

### DIFF
--- a/Killall.pm
+++ b/Killall.pm
@@ -10,6 +10,7 @@ use Carp;
 use Proc::ProcessTable;
 use Config;
 use strict;
+use warnings;
 use vars qw(@EXPORT @EXPORT_OK @ISA $VERSION);
 
 @EXPORT=qw(killall);

--- a/Killfam.pm
+++ b/Killfam.pm
@@ -7,6 +7,7 @@ use base qw/Exporter/;
 use subs qw/get_pids/;
 use vars qw/@EXPORT @EXPORT_OK $ppt_OK/;
 use strict;
+use warnings;
 
 @EXPORT = qw/killfam/;
 @EXPORT_OK = qw/killfam/;

--- a/Process/Process.pm
+++ b/Process/Process.pm
@@ -1,6 +1,7 @@
 package Proc::ProcessTable::Process;
 
 use strict;
+use warnings;
 use vars qw($VERSION @ISA @EXPORT @EXPORT_OK $AUTOLOAD);
 
 require Exporter;

--- a/ProcessTable.pm
+++ b/ProcessTable.pm
@@ -3,6 +3,7 @@ package Proc::ProcessTable;
 use 5.006;
 
 use strict;
+use warnings;
 use Carp;
 use Fcntl;
 use Config;


### PR DESCRIPTION
While I was looking at RT-Ticket [#100048](https://rt.cpan.org/Ticket/Display.html?id=100048) I understood the said problem was invalid. So I decided to leave this distribution behind a little (tinytiny) bit better than I found it and enabled `use warnings;` .