### PR TITLE
use cygwin_conv_path in place of deprecated and removed cygwin_conv_to_p...

### DIFF
--- a/os/cygwin.c
+++ b/os/cygwin.c
@@ -218,7 +218,7 @@ OS_get_table()
 	{
 	  char *s;
 	  pname[0] = '\0';
-	  cygwin_conv_to_posix_path (p->progname, pname);
+	  cygwin_conv_path(CCP_WIN_A_TO_POSIX, p->progname, pname, PATH_MAX);
 	  s = strchr (pname, '\0') - 4;
 	  if (s > pname && strcasecmp (s, ".exe") == 0)
 	    *s = '\0';


### PR DESCRIPTION
This fixes failures like this:

http://www.cpantesters.org/cpan/report/54472c98-7eea-11e4-bac9-aefdffac3ecd

for me.