### PR TITLE
Got rid of indirect object notation

### DIFF
--- a/Killall.pm
+++ b/Killall.pm
@@ -49,7 +49,7 @@ sub killall {
 	$self = 0 unless defined $self;
 	my $nkilled = 0;
 	croak("killall: Unsupported signal: $signal") unless is_sig($signal);
-	my $t = new Proc::ProcessTable;
+	my $t = Proc::ProcessTable->new;
 	my $BANG = undef;
 	foreach my $p (@{$t->table}) {
 	  my $cmndline = $p->{cmndline} || $p->{fname};

--- a/ProcessTable.pm
+++ b/ProcessTable.pm
@@ -169,9 +169,9 @@ Proc::ProcessTable - Perl extension to access the unix process table
 
   use Proc::ProcessTable;
 
-  $p = new Proc::ProcessTable( 'cache_ttys' => 1 ); 
-  @fields = $p->fields;
-  $ref = $p->table;
+  my $p = Proc::ProcessTable->new( 'cache_ttys' => 1 ); 
+  my @fields = $p->fields;
+  my $ref = $p->table;
 
 =head1 DESCRIPTION
 
@@ -225,10 +225,10 @@ are supported directly by internal perl functions.
  # A cheap and sleazy version of ps
  use Proc::ProcessTable;
 
- $FORMAT = "%-6s %-10s %-8s %-24s %s\n";
- $t = new Proc::ProcessTable;
+ my $FORMAT = "%-6s %-10s %-8s %-24s %s\n";
+ my $t = Proc::ProcessTable->new;
  printf($FORMAT, "PID", "TTY", "STAT", "START", "COMMAND"); 
- foreach $p ( @{$t->table} ){
+ foreach my $p ( @{$t->table} ){
    printf($FORMAT, 
           $p->pid, 
           $p->ttydev, 
@@ -241,11 +241,11 @@ are supported directly by internal perl functions.
  # Dump all the information in the current process table
  use Proc::ProcessTable;
 
- $t = new Proc::ProcessTable;
+ my $t = Proc::ProcessTable->new;
 
- foreach $p (@{$t->table}) {
+ foreach my $p (@{$t->table}) {
   print "--------------------------------\n";
-  foreach $f ($t->fields){
+  foreach my $f ($t->fields){
     print $f, ":  ", $p->{$f}, "\n";
   }
  }              

--- a/ProcessTable.xs
+++ b/ProcessTable.xs
@@ -317,7 +317,7 @@ table(obj)
 
      /* Check that we have an actual object. 
        calling Proc::Processtable->table SIGSEVs
-       calling on an actual object is valid my $proc_obj = new Proc::ProcessTable; $proc_obj->table; 
+       calling on an actual object is valid my $proc_obj = Proc::ProcessTable->new; $proc_obj->table; 
      */
      if (!obj || !SvOK (obj) || !SvROK (obj) || !sv_isobject (obj)) {
          croak("Must call table from an initalized object created with new");

--- a/README
+++ b/README
@@ -55,15 +55,15 @@ very efficient or aesthetic way to do things.
 
 With this module, you can do things like this:
 
-	# kill memory pigs 
-	use Proc::ProcessTable;
+    # kill memory pigs 
+    use Proc::ProcessTable;
 
-	$t = new Proc::ProcessTable;
-        foreach $p ( @{$t->table} ){	
-	  if( $p->pctmem > 95 ){
-	    $p->kill(9);
-          }		
-        }
+    my $t = Proc::ProcessTable->new;
+    foreach my $p ( @{$t->table} ) {
+        if( $p->pctmem > 95 ){
+	        $p->kill(9);
+        }		
+    }
 
 There is another short example in the file "example.pl" in the
 distribution. For a more elaborate example (in German), see

--- a/contrib/pswait
+++ b/contrib/pswait
@@ -4,7 +4,7 @@ use Proc::ProcessTable;
 
 exit if ( $#ARGV == -1 );
 $|++;
-my $ptable = new Proc::ProcessTable;
+my $ptable = Proc::ProcessTable->new;
 my %waited = ();
 my %proc;
 $proc{ $_->pid }=$_->fname foreach (@{$ptable->table});

--- a/example.pl
+++ b/example.pl
@@ -2,15 +2,15 @@
 
 use Proc::ProcessTable;
 
-$ref = new Proc::ProcessTable;
+my $ref = Proc::ProcessTable->new;
 
-foreach $proc (@{$ref->table}) {
+foreach my $proc (@{$ref->table}) {
   if(@ARGV) {
     next unless grep {$_ == $proc->{pid}} @ARGV;
   }
 
   print "--------------------------------\n";
-  foreach $field ($ref->fields){
+  foreach my $field ($ref->fields){
     print $field, ":  ", $proc->{$field}, "\n";
   }
 }

--- a/t/process.t
+++ b/t/process.t
@@ -13,7 +13,7 @@ use Proc::ProcessTable;
 $SIG{CHLD} = sub{wait;};
 my ( $got, $field );
 
-my $t = new Proc::ProcessTable;
+my $t = Proc::ProcessTable->new;
 
 # Is there a process called cron
 foreach $got ( @{$t->table} )


### PR DESCRIPTION
The documentation for the module had some indirect object notation used.  That all got updated to ```Foo->new()``` instead