### PR TITLE
FreeBSD-kvm: remove trailing space from cmndline output (RT #111038)

### DIFF
--- a/os/FreeBSD-kvm.c
+++ b/os/FreeBSD-kvm.c
@@ -80,9 +80,11 @@ void OS_get_table(){
      argv = kvm_getargv(kd, (const struct kinfo_proc *) &(procs[i]) , 0);
      if (argv) {
        int j = 0;
-       while (argv[j] && strlen(cmndline) <= ARG_MAX) {
+       while (argv[j] && strlen(cmndline)+strlen(argv[j])+1 <= ARG_MAX) {
          strcat(cmndline, argv[j]);
-         strcat(cmndline, " ");
+	 if (argv[j+1]) {
+	   strcat(cmndline, " ");
+	 }
          j++;
        }
      }


### PR DESCRIPTION
In the FreeBSD implementation, cmndline used to emit an unnecessary
trailing space.

Additionally, it's made sure that cmndline never gets larger than ARG_MAX
(however, in my real-world experiments I never managed to produce an argv
big enough for segmentation faults).