### PR TITLE
more implementations with trailing space (RT #111038)

### DIFF
--- a/os/OpenBSD.c
+++ b/os/OpenBSD.c
@@ -128,9 +128,11 @@ void OS_get_table() {
 		pargv = kvm_getargv(kd, (const struct kinfo_proc *) &(procs[i]), 0);
 		if (pargv) {
 			argcount = 0;
-			while (pargv[argcount] && strlen(cmndline) <= ARG_MAX) {
+			while (pargv[argcount] && strlen(cmndline)+strlen(pargv[argcount])+1 <= ARG_MAX) {
 				STRLCAT(1,cmndline,pargv[argcount]);
-				STRLCAT(2,cmndline," ");
+				if (pargv[argcount+1]) {
+					STRLCAT(2,cmndline," ");
+				}
 				argcount++;
 			}
 		}

--- a/os/bsdi.c
+++ b/os/bsdi.c
@@ -153,9 +153,11 @@ void OS_get_table() {
 	argv = kvm_getargv(kd, (const struct kinfo_proc *) &(procs[i]) , 0);
 	if (argv) {
 	  int j = 0;
-	  while (argv[j] && strlen(cmndline) <= MAXARGLN) {
+	  while (argv[j] && strlen(cmndline)+strlen(argv[j])+1 <= MAXARGLN) {
 		strcat(cmndline, argv[j]);
-		strcat(cmndline, " ");
+		if (argv[j+1]) {
+		  strcat(cmndline, " ");
+		}
 		j++;
 	  }
 	}


### PR DESCRIPTION
It seems that the OpenBSD and bsdi implementations
also generate trailing space in the cmndline call.
Here's a patch, however completely untested (it
could even fail to compile).
