### PR TITLE
Add percent cpu field to FreeBSD kvm implementation

### DIFF
--- a/README.freebsd-kvm
+++ b/README.freebsd-kvm
@@ -8,6 +8,7 @@ SUPPORTED ATTRIBUTES
   groups       array of group ids
   pgrp         process GID
   sess         process session ID
+  jid          Jail ID
 
   flags        P_* flags
   sflags       PS_* flags
@@ -18,6 +19,7 @@ SUPPORTED ATTRIBUTES
   ctime        running child time (in seconds)
   cutime       child user time (in seconds)
   cstime       child system time (in seconds)
+  pctcpu       percent CPU usage
   wchan        current system call
   state        state of process
 

--- a/os/FreeBSD-kvm.h
+++ b/os/FreeBSD-kvm.h
@@ -13,7 +13,7 @@
 
 /* We need to pass in a cap for ignore, lower for store on object */
 /* We can just lc these! */
-static char Defaultformat[] = "iiiiiiiissssssssssssissiiiiiiiiiiiiiiVV";
+static char Defaultformat[] = "iiiiiiiisssssssssssssissiiiiiiiiiiiiiiVV";
 
 /* Mapping of field to type */
 static char* Fields[] = {
@@ -36,6 +36,7 @@ static char* Fields[] = {
     "ctime",
     "cutime",
     "cstime",
+    "pctcpu",
 
     "wchan",
     "state",


### PR DESCRIPTION
- FreeBSD KVM implementation gets a new field which signifies
  the percent CPU usage of each process. The code used was copied
  as faithfully as possible from the FreeBSD sources, specifically
  from the implementation of the ps command. For future reference,
  the relevant files were bin/ps/ps.c, bin/ps/ps.h and
  bin/ps/print.c.
- Btw add the missing jid field in the README.freebsd-kvm file.
