### PR TITLE
Add "rss" and "size" attribute on OpenBSD

### DIFF
--- a/README.openbsd
+++ b/README.openbsd
@@ -12,6 +12,7 @@ time             cpu time of process
 utime            user time
 stime            system time
 start            time process started
+size             virtual memory size (bytes)
 fname            command name    
 state            state of process
 ttydev           path of process' tty

--- a/README.openbsd
+++ b/README.openbsd
@@ -13,6 +13,7 @@ utime            user time
 stime            system time
 start            time process started
 size             virtual memory size (bytes)
+rss              resident set size (bytes)
 fname            command name    
 state            state of process
 ttydev           path of process' tty

--- a/os/OpenBSD.c
+++ b/os/OpenBSD.c
@@ -28,7 +28,7 @@
 
 /* We need to pass in a cap for ignore, lower for store on object */
 /* We can just lc these! */
-static char Defaultformat[] = "liiiiiiiiiiiissss";
+static char Defaultformat[] = "liiiiiiiiiiiilssss";
 
 /* Mapping of field to type */
 static char* Fields[] = {
@@ -45,12 +45,13 @@ static char* Fields[] = {
 	"utime",
 	"stime",
 	"start",
+	"size",
 	"fname",
 	"state",
 	"ttydev",
 	"cmndline"
 };
-#define F_LASTFIELD 16
+#define F_LASTFIELD 17
 
 /* Set up simple bounds checking */
 #define STRLCPY(num,targ,src) if (strlcpy(targ,src,sizeof(targ)) >= sizeof(targ)) \
@@ -73,6 +74,7 @@ void OS_get_table() {
 	int i, argcount;
 	int ttynum;
 	long start;
+        unsigned long vsize;
 	char *ttydev;
 	char cmndline[ARG_MAX+1];
 	char **pargv;
@@ -123,6 +125,8 @@ void OS_get_table() {
 				break;
 		}
 
+		vsize = getpagesize() * (procs[i].p_vm_dsize + procs[i].p_vm_ssize + procs[i].p_vm_tsize);
+
 		/* arguments */
 		cmndline[0] = '\0';
 		pargv = kvm_getargv(kd, (const struct kinfo_proc *) &(procs[i]), 0);
@@ -153,6 +157,7 @@ void OS_get_table() {
 			procs[i].p_uutime_sec,
 			procs[i].p_ustime_sec,
 			procs[i].p_ustart_sec,
+			vsize,
 			procs[i].p_comm,
 			state,
 			ttydev,

--- a/os/OpenBSD.c
+++ b/os/OpenBSD.c
@@ -28,7 +28,7 @@
 
 /* We need to pass in a cap for ignore, lower for store on object */
 /* We can just lc these! */
-static char Defaultformat[] = "liiiiiiiiiiiilssss";
+static char Defaultformat[] = "liiiiiiiiiiiillssss";
 
 /* Mapping of field to type */
 static char* Fields[] = {
@@ -46,12 +46,13 @@ static char* Fields[] = {
 	"stime",
 	"start",
 	"size",
+	"rss",
 	"fname",
 	"state",
 	"ttydev",
 	"cmndline"
 };
-#define F_LASTFIELD 17
+#define F_LASTFIELD 18
 
 /* Set up simple bounds checking */
 #define STRLCPY(num,targ,src) if (strlcpy(targ,src,sizeof(targ)) >= sizeof(targ)) \
@@ -74,7 +75,8 @@ void OS_get_table() {
 	int i, argcount;
 	int ttynum;
 	long start;
-        unsigned long vsize;
+	unsigned long vsize;
+	unsigned long rss;
 	char *ttydev;
 	char cmndline[ARG_MAX+1];
 	char **pargv;
@@ -126,6 +128,7 @@ void OS_get_table() {
 		}
 
 		vsize = getpagesize() * (procs[i].p_vm_dsize + procs[i].p_vm_ssize + procs[i].p_vm_tsize);
+		rss   = getpagesize() * procs[i].p_vm_rssize;
 
 		/* arguments */
 		cmndline[0] = '\0';
@@ -158,6 +161,7 @@ void OS_get_table() {
 			procs[i].p_ustime_sec,
 			procs[i].p_ustart_sec,
 			vsize,
+			rss,
 			procs[i].p_comm,
 			state,
 			ttydev,

--- a/t/openbsd-size-rss.t
+++ b/t/openbsd-size-rss.t
@@ -1,4 +1,4 @@
-# Test size attribute on OpenBSD
+# Test size & RSS attribute on OpenBSD
 # Added by Joelle Maslak <jmaslak@antelope.net>, used bugfix-51470 for
 # outline.
 
@@ -34,13 +34,16 @@ SKIP: {
     sleep 1;
     diag "process: " . `ps -lp $pid `;
 
-    my $pstmp = `ps -p $pid -o vsz`;
+    my $pstmp = `ps -p $pid -o vsz,rss`;
     my (@lines) = split '\n', $pstmp;
-    my $ps_vsize = $lines[1] * 1024;
+    my (@parts) = split /\s+/, $lines[1];
+    my $ps_vsize = $parts[0] * 1024;
+    my $ps_rss   = $parts[1] * 1024;
 
     my $t   = Proc::ProcessTable->new;
     my ($p) = grep { $_->{pid} == $pid } @{ $t->table };
     is( $p->{size}, $ps_vsize, "Process size = ps vsz" );
+    is( $p->{rss},  $ps_rss,   "Process rss  = ps rss" );
     diag "process info: " . Dumper($p);
     kill 9, $pid;
   }

--- a/t/openbsd-size.t
+++ b/t/openbsd-size.t
@@ -1,0 +1,49 @@
+# Test size attribute on OpenBSD
+# Added by Joelle Maslak <jmaslak@antelope.net>, used bugfix-51470 for
+# outline.
+
+use warnings;
+use Test::More;
+use Data::Dumper;
+
+BEGIN {
+  if ( $^O ne 'openbsd' ) {
+    plan skip_all => 'OpenBSD-specific tests';
+  }
+
+  use_ok('Proc::ProcessTable');
+}
+
+SKIP: {
+  $0 = "PROC_PROCESSTABLE_TEST_CMD";
+  sleep(1);
+
+  skip 'Cannot set process name', 1
+    unless ( `ps hwwp $$` =~ /PROC_PROCESSTABLE_TEST_CMD/ );
+
+  $SIG{CHLD} = 'IGNORE';
+
+  my $pid = fork;
+  die "cannot fork" unless defined $pid;
+
+  if ( $pid == 0 ) {
+    #child
+    sleep 10000;
+  } else {
+    #main
+    sleep 1;
+    diag "process: " . `ps -lp $pid `;
+
+    my $pstmp = `ps -p $pid -o vsz`;
+    my (@lines) = split '\n', $pstmp;
+    my $ps_vsize = $lines[1] * 1024;
+
+    my $t   = Proc::ProcessTable->new;
+    my ($p) = grep { $_->{pid} == $pid } @{ $t->table };
+    is( $p->{size}, $ps_vsize, "Process size = ps vsz" );
+    diag "process info: " . Dumper($p);
+    kill 9, $pid;
+  }
+}
+done_testing();
+


### PR DESCRIPTION
This patch adds the "rss" and "size" attributes for OpenBSD, along with tests.