### PR TITLE
Do not get TTY list if /dev directory does not exist

### DIFF
--- a/lib/Proc/ProcessTable.pm
+++ b/lib/Proc/ProcessTable.pm
@@ -152,6 +152,7 @@ sub _get_tty_list
 {
   my ($self) = @_;
   undef %Proc::ProcessTable::TTYDEVS;
+  return unless -d "/dev";
   find({ wanted => 
        sub{
      $File::Find::prune = 1 if -d $_ && ! -x $_;


### PR DESCRIPTION
If not skipped, on native MSWin32, we get an [error message](https://travis-ci.org/jwbargsten/perl-proc-processtable/jobs/623378139#L86):

```
Can't stat /dev: No such file or directory

 at C:\Users\travis\build\jwbargsten\perl-proc-processtable\blib\lib/Proc/ProcessTable.pm line 162.
```