### PR TITLE
Skip LXC hidden dir in /dev when looking for TTYs

### DIFF
--- a/lib/Proc/ProcessTable.pm
+++ b/lib/Proc/ProcessTable.pm
@@ -155,7 +155,7 @@ sub _get_tty_list
   return unless -d "/dev";
   find({ wanted => 
        sub{
-     $File::Find::prune = 1 if -d $_ && ! -x $_;
+     $File::Find::prune = 1 if -d $_ && ( ! -x $_ || $_ eq "/dev/.lxc");
      my($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size,
         $atime,$mtime,$ctime,$blksize,$blocks) = stat($File::Find::name);
      $Proc::ProcessTable::TTYDEVS{$rdev} = $File::Find::name


### PR DESCRIPTION
In LXC containers, /dev/.lxc contains subdirs for the sys and proc fs to be mounted into the container. These files are not readable directly, Proc::ProcessTable::_get_tty_list attempts to stat the files in these directories which results in a lot of warnings. There aren't going to be any TTY device files there so you can skip the whole dir.

For an example of this causing issues, see liske/needrestart#170 .