### PR TITLE
allow (again) processes with empty names

### DIFF
--- a/os/Linux.c
+++ b/os/Linux.c
@@ -343,8 +343,6 @@ static bool get_proc_stat(char *pid, char *format_str, struct procstat* prs,
     if(comm_len > 0) {
       strncpy(prs->comm, open_paren + 1, comm_esize);
       prs->comm[comm_esize] = '\0';
-    } else {
-      prs->comm[0] = '\0';
     }
 
 

--- a/os/Linux.c
+++ b/os/Linux.c
@@ -340,12 +340,13 @@ static bool get_proc_stat(char *pid, char *format_str, struct procstat* prs,
     if(comm_len > comm_esize) {
       comm_len = comm_esize;
     }
-    if(comm_len == 0) {
-      goto done;
+    if(comm_len > 0) {
+      strncpy(prs->comm, open_paren + 1, comm_esize);
+      prs->comm[comm_esize] = '\0';
+    } else {
+      prs->comm[0] = '\0';
     }
 
-    strncpy(prs->comm, open_paren + 1, comm_esize);
-    prs->comm[comm_esize] = '\0';
 
     /* address at which we pickup again, after the ')'
      * NOTE: we don't bother checking bounds since strchr didn't return NULL


### PR DESCRIPTION
Bug #139258 for Proc-ProcessTable: Ran into unknown state (hex char: 0)

https://rt.cpan.org/Public/Bug/Display.html?id=139258