### PR TITLE
Cygwin implementation

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl extension Proc::ProcessTable.
 
+0.631 2021-09-26
+  - added cygwin implementation/extension of ASSI
+  - aaand we are back to 3-digit version numbers due to quirks
+    of rpmvercmp, which thinks that 0.612 is higer than 0.62
+
 0.62 2021-09-13
   - updated Changes file to stick to perl5-module-meta recommendations
   - changed version scheme back to 2 digits after major version.

--- a/MANIFEST
+++ b/MANIFEST
@@ -33,12 +33,17 @@ lib/Proc/ProcessTable.pm
 lib/Proc/ProcessTable/Process.pm
 Makefile.PL
 MANIFEST			This list of files
+obstack.h
+obstack.c
+obstack_printf.c
 os/aix.c
 os/aix.h
 os/aix_getprocs.c
 os/aix_getprocs.h
 os/bsdi.c
 os/bsdi.h
+os/Cygwin.c
+os/Cygwin.h
 os/darwin.c
 os/darwin.h
 os/DecOSF.c

--- a/README.cygwin
+++ b/README.cygwin
@@ -1,11 +1,38 @@
 SUPPORTED ATTRIBUTES
 ====================
-  uid		UID of process
-  pid		process ID
-  ppid		parent process ID
-  pgid		process group ID
-  winpid	Windows process ID
-  fname		file name
-  start		start time (seconds since the epoch)
-  ttynum	tty number of process
-  state		state of process
+  uid         UID of process
+  euid        Effective UID of process
+  suid        Saved UID of process
+  fuid        File UID of process
+  gid         GID of process
+  egid        Effective GID of process
+  sgid        Saved GID of process
+  fgid        File GID of process
+  pid         process ID
+  ppid        parent process ID
+  pgrp        process group
+  sess        session ID
+  priority    priority of process
+  ttynum      tty number of process
+  flags       flags of process
+  minflt      minor page faults
+  cminflt     child minor page faults
+  majflt      major page faults
+  cmajflt     child major page faults
+  utime       user mode time (microseconds)
+  stime       kernel mode time (microseconds)
+  cutime      child utime (microseconds)
+  cstime      child stime (microseconds)
+  time        user + system time (microseconds)
+  ctime       child user + system time (microseconds)
+  size        virtual memory size (bytes)
+  rss         resident set size (bytes)
+  fname       file name
+  start       start time (seconds since the epoch)
+  pctcpu      percent cpu used since process started
+  state       state of process
+  pctmem      percent memory
+  cmndline    full command line of process
+  exec        absolute filename (including path) of executed command
+  ttydev      path of process's tty
+  cwd         current directory of process

--- a/hints/cygwin.pl
+++ b/hints/cygwin.pl
@@ -1,3 +1,3 @@
-symlink "os/MSWin32.c", "OS.c" || die "Could not link os/MSWin32.c to OS.c\n";
-
-$self->{DEFINE} .= " -DUSE_CYGWIN";
+symlink "os/Cygwin.c", "OS.c" || die "Could not link os/Cygwin.c to OS.c\n";
+delete $self->{LIBS};
+$self->{OBJECT} .= ' obstack.o obstack_printf.o';

--- a/lib/Proc/ProcessTable.pm
+++ b/lib/Proc/ProcessTable.pm
@@ -18,7 +18,7 @@ require DynaLoader;
 @EXPORT = qw(
     
 );
-$VERSION = '0.62';
+$VERSION = '0.631';
 
 sub AUTOLOAD {
     # This AUTOLOAD is used to 'autoload' constants from the constant()

--- a/obstack.c
+++ b/obstack.c
@@ -1,0 +1,376 @@
+/* obstack.c - subroutines used implicitly by object stack macros
+   Copyright (C) 1988-2021 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+
+#ifdef _LIBC
+# include <obstack.h>
+#else
+# include <config.h>
+# include "obstack.h"
+#endif
+
+/* NOTE BEFORE MODIFYING THIS FILE: _OBSTACK_INTERFACE_VERSION in
+   obstack.h must be incremented whenever callers compiled using an old
+   obstack.h can no longer properly call the functions in this file.  */
+
+/* Comment out all this code if we are using the GNU C Library, and are not
+   actually compiling the library itself, and the installed library
+   supports the same library interface we do.  This code is part of the GNU
+   C Library, but also included in many other GNU distributions.  Compiling
+   and linking in this code is a waste when using the GNU C library
+   (especially if it is a shared library).  Rather than having every GNU
+   program understand 'configure --with-gnu-libc' and omit the object
+   files, it is simpler to just do this in the source for each such file.  */
+#if !defined _LIBC && defined __GNU_LIBRARY__ && __GNU_LIBRARY__ > 1
+# include <gnu-versions.h>
+# if (_GNU_OBSTACK_INTERFACE_VERSION == _OBSTACK_INTERFACE_VERSION	      \
+      || (_GNU_OBSTACK_INTERFACE_VERSION == 1				      \
+          && _OBSTACK_INTERFACE_VERSION == 2				      \
+          && defined SIZEOF_INT && defined SIZEOF_SIZE_T		      \
+          && SIZEOF_INT == SIZEOF_SIZE_T))
+#  define _OBSTACK_ELIDE_CODE
+# endif
+#endif
+
+#ifndef _OBSTACK_ELIDE_CODE
+/* If GCC, or if an oddball (testing?) host that #defines __alignof__,
+   use the already-supplied __alignof__.  Otherwise, this must be Gnulib
+   (as glibc assumes GCC); defer to Gnulib's alignof_type.  */
+# if !defined __GNUC__ && !defined __IBM__ALIGNOF__ && !defined __alignof__
+#  if defined __cplusplus
+template <class type> struct alignof_helper { char __slot1; type __slot2; };
+#   define __alignof__(type) offsetof (alignof_helper<type>, __slot2)
+#  else
+#   define __alignof__(type)						      \
+  offsetof (struct { char __slot1; type __slot2; }, __slot2)
+#  endif
+# endif
+# include <stdlib.h>
+# include <stdint.h>
+
+# ifndef MAX
+#  define MAX(a,b) ((a) > (b) ? (a) : (b))
+# endif
+
+/* Determine default alignment.  */
+
+/* If malloc were really smart, it would round addresses to DEFAULT_ALIGNMENT.
+   But in fact it might be less smart and round addresses to as much as
+   DEFAULT_ROUNDING.  So we prepare for it to do that.
+
+   DEFAULT_ALIGNMENT cannot be an enum constant; see gnulib's alignof.h.  */
+#define DEFAULT_ALIGNMENT MAX (__alignof__ (long double),		      \
+                               MAX (__alignof__ (uintmax_t),		      \
+                                    __alignof__ (void *)))
+#define DEFAULT_ROUNDING MAX (sizeof (long double),			      \
+                               MAX (sizeof (uintmax_t),			      \
+                                    sizeof (void *)))
+
+/* Call functions with either the traditional malloc/free calling
+   interface, or the mmalloc/mfree interface (that adds an extra first
+   argument), based on the value of use_extra_arg.  */
+
+static void *
+call_chunkfun (struct obstack *h, size_t size)
+{
+  if (h->use_extra_arg)
+    return h->chunkfun.extra (h->extra_arg, size);
+  else
+    return h->chunkfun.plain (size);
+}
+
+static void
+call_freefun (struct obstack *h, void *old_chunk)
+{
+  if (h->use_extra_arg)
+    h->freefun.extra (h->extra_arg, old_chunk);
+  else
+    h->freefun.plain (old_chunk);
+}
+
+
+/* Initialize an obstack H for use.  Specify chunk size SIZE (0 means default).
+   Objects start on multiples of ALIGNMENT (0 means use default).
+
+   Return nonzero if successful, calls obstack_alloc_failed_handler if
+   allocation fails.  */
+
+static int
+_obstack_begin_worker (struct obstack *h,
+                       _OBSTACK_SIZE_T size, _OBSTACK_SIZE_T alignment)
+{
+  struct _obstack_chunk *chunk; /* points to new chunk */
+
+  if (alignment == 0)
+    alignment = DEFAULT_ALIGNMENT;
+  if (size == 0)
+    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
+    {
+      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
+         Use the values for range checking, because if range checking is off,
+         the extra bytes won't be missed terribly, but if range checking is on
+         and we used a larger request, a whole extra 4096 bytes would be
+         allocated.
+
+         These number are irrelevant to the new GNU malloc.  I suspect it is
+         less sensitive to the size of the request.  */
+      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
+                    + 4 + DEFAULT_ROUNDING - 1)
+                   & ~(DEFAULT_ROUNDING - 1));
+      size = 4096 - extra;
+    }
+
+  h->chunk_size = size;
+  h->alignment_mask = alignment - 1;
+
+  chunk = (struct _obstack_chunk *) call_chunkfun (h, h->chunk_size);
+  if (!chunk)
+    (*obstack_alloc_failed_handler) ();
+  h->chunk = chunk;
+  h->next_free = h->object_base = __PTR_ALIGN ((char *) chunk, chunk->contents,
+                                               alignment - 1);
+  h->chunk_limit = chunk->limit = (char *) chunk + h->chunk_size;
+  chunk->prev = 0;
+  /* The initial chunk now contains no empty object.  */
+  h->maybe_empty_object = 0;
+  h->alloc_failed = 0;
+  return 1;
+}
+
+int
+_obstack_begin (struct obstack *h,
+                _OBSTACK_SIZE_T size, _OBSTACK_SIZE_T alignment,
+                void *(*chunkfun) (size_t),
+                void (*freefun) (void *))
+{
+  h->chunkfun.plain = chunkfun;
+  h->freefun.plain = freefun;
+  h->use_extra_arg = 0;
+  return _obstack_begin_worker (h, size, alignment);
+}
+
+int
+_obstack_begin_1 (struct obstack *h,
+                  _OBSTACK_SIZE_T size, _OBSTACK_SIZE_T alignment,
+                  void *(*chunkfun) (void *, size_t),
+                  void (*freefun) (void *, void *),
+                  void *arg)
+{
+  h->chunkfun.extra = chunkfun;
+  h->freefun.extra = freefun;
+  h->extra_arg = arg;
+  h->use_extra_arg = 1;
+  return _obstack_begin_worker (h, size, alignment);
+}
+
+/* Allocate a new current chunk for the obstack *H
+   on the assumption that LENGTH bytes need to be added
+   to the current object, or a new object of length LENGTH allocated.
+   Copies any partial object from the end of the old chunk
+   to the beginning of the new one.  */
+
+void
+_obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
+{
+  struct _obstack_chunk *old_chunk = h->chunk;
+  struct _obstack_chunk *new_chunk = 0;
+  size_t obj_size = h->next_free - h->object_base;
+  char *object_base;
+
+  /* Compute size for new chunk.  */
+  size_t sum1 = obj_size + length;
+  size_t sum2 = sum1 + h->alignment_mask;
+  size_t new_size = sum2 + (obj_size >> 3) + 100;
+  if (new_size < sum2)
+    new_size = sum2;
+  if (new_size < h->chunk_size)
+    new_size = h->chunk_size;
+
+  /* Allocate and initialize the new chunk.  */
+  if (obj_size <= sum1 && sum1 <= sum2)
+    new_chunk = (struct _obstack_chunk *) call_chunkfun (h, new_size);
+  if (!new_chunk)
+    (*obstack_alloc_failed_handler)();
+  h->chunk = new_chunk;
+  new_chunk->prev = old_chunk;
+  new_chunk->limit = h->chunk_limit = (char *) new_chunk + new_size;
+
+  /* Compute an aligned object_base in the new chunk */
+  object_base =
+    __PTR_ALIGN ((char *) new_chunk, new_chunk->contents, h->alignment_mask);
+
+  /* Move the existing object to the new chunk.  */
+  memcpy (object_base, h->object_base, obj_size);
+
+  /* If the object just copied was the only data in OLD_CHUNK,
+     free that chunk and remove it from the chain.
+     But not if that chunk might contain an empty object.  */
+  if (!h->maybe_empty_object
+      && (h->object_base
+          == __PTR_ALIGN ((char *) old_chunk, old_chunk->contents,
+                          h->alignment_mask)))
+    {
+      new_chunk->prev = old_chunk->prev;
+      call_freefun (h, old_chunk);
+    }
+
+  h->object_base = object_base;
+  h->next_free = h->object_base + obj_size;
+  /* The new chunk certainly contains no empty object yet.  */
+  h->maybe_empty_object = 0;
+}
+
+/* Return nonzero if object OBJ has been allocated from obstack H.
+   This is here for debugging.
+   If you use it in a program, you are probably losing.  */
+
+/* Suppress -Wmissing-prototypes warning.  We don't want to declare this in
+   obstack.h because it is just for debugging.  */
+int _obstack_allocated_p (struct obstack *h, void *obj) __attribute_pure__;
+
+int
+_obstack_allocated_p (struct obstack *h, void *obj)
+{
+  struct _obstack_chunk *lp;    /* below addr of any objects in this chunk */
+  struct _obstack_chunk *plp;   /* point to previous chunk if any */
+
+  lp = (h)->chunk;
+  /* We use >= rather than > since the object cannot be exactly at
+     the beginning of the chunk but might be an empty object exactly
+     at the end of an adjacent chunk.  */
+  while (lp != 0 && ((void *) lp >= obj || (void *) (lp)->limit < obj))
+    {
+      plp = lp->prev;
+      lp = plp;
+    }
+  return lp != 0;
+}
+
+/* Free objects in obstack H, including OBJ and everything allocate
+   more recently than OBJ.  If OBJ is zero, free everything in H.  */
+
+void
+_obstack_free (struct obstack *h, void *obj)
+{
+  struct _obstack_chunk *lp;    /* below addr of any objects in this chunk */
+  struct _obstack_chunk *plp;   /* point to previous chunk if any */
+
+  lp = h->chunk;
+  /* We use >= because there cannot be an object at the beginning of a chunk.
+     But there can be an empty object at that address
+     at the end of another chunk.  */
+  while (lp != 0 && ((void *) lp >= obj || (void *) (lp)->limit < obj))
+    {
+      plp = lp->prev;
+      call_freefun (h, lp);
+      lp = plp;
+      /* If we switch chunks, we can't tell whether the new current
+         chunk contains an empty object, so assume that it may.  */
+      h->maybe_empty_object = 1;
+    }
+  if (lp)
+    {
+      h->object_base = h->next_free = (char *) (obj);
+      h->chunk_limit = lp->limit;
+      h->chunk = lp;
+    }
+  else if (obj != 0)
+    /* obj is not in any of the chunks! */
+    abort ();
+}
+
+_OBSTACK_SIZE_T
+_obstack_memory_used (struct obstack *h)
+{
+  struct _obstack_chunk *lp;
+  _OBSTACK_SIZE_T nbytes = 0;
+
+  for (lp = h->chunk; lp != 0; lp = lp->prev)
+    {
+      nbytes += lp->limit - (char *) lp;
+    }
+  return nbytes;
+}
+
+# ifndef _OBSTACK_NO_ERROR_HANDLER
+/* Define the error handler.  */
+#  include <stdio.h>
+
+/* Exit value used when 'print_and_abort' is used.  */
+#  ifdef _LIBC
+int obstack_exit_failure = EXIT_FAILURE;
+#  else
+#   ifndef EXIT_FAILURE
+#    define EXIT_FAILURE 1
+#   endif
+#   define obstack_exit_failure EXIT_FAILURE
+#  endif
+
+#  if defined _LIBC || (HAVE_LIBINTL_H && ENABLE_NLS)
+#   include <libintl.h>
+#   ifndef _
+#    define _(msgid) gettext (msgid)
+#   endif
+#  else
+#   ifndef _
+#    define _(msgid) (msgid)
+#   endif
+#  endif
+
+#  if !(defined _Noreturn						      \
+        || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112))
+#   if ((defined __GNUC__						      \
+	 && (__GNUC__ >= 3 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 8)))	      \
+	|| (defined __SUNPRO_C && __SUNPRO_C >= 0x5110))
+#    define _Noreturn __attribute__ ((__noreturn__))
+#   elif defined _MSC_VER && _MSC_VER >= 1200
+#    define _Noreturn __declspec (noreturn)
+#   else
+#    define _Noreturn
+#   endif
+#  endif
+
+#  ifdef _LIBC
+#   include <libio/iolibio.h>
+#  endif
+
+static _Noreturn void
+print_and_abort (void)
+{
+  /* Don't change any of these strings.  Yes, it would be possible to add
+     the newline to the string and use fputs or so.  But this must not
+     happen because the "memory exhausted" message appears in other places
+     like this and the translation should be reused instead of creating
+     a very similar string which requires a separate translation.  */
+#  ifdef _LIBC
+  (void) __fxprintf (NULL, "%s\n", _("memory exhausted"));
+#  else
+  fprintf (stderr, "%s\n", _("memory exhausted"));
+#  endif
+  exit (obstack_exit_failure);
+}
+
+/* The functions allocating more room by calling 'obstack_chunk_alloc'
+   jump to the handler pointed to by 'obstack_alloc_failed_handler'.
+   This can be set to a user defined function which should either
+   abort gracefully or use longjump - but shouldn't return.  This
+   variable by default points to the internal function
+   'print_and_abort'.  */
+void (*obstack_alloc_failed_handler) (void) = print_and_abort;
+# endif /* !_OBSTACK_NO_ERROR_HANDLER */
+#endif /* !_OBSTACK_ELIDE_CODE */

--- a/obstack.h
+++ b/obstack.h
@@ -1,0 +1,538 @@
+/* obstack.h - object stack macros
+   Copyright (C) 1988-2021 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+/* Summary:
+
+   All the apparent functions defined here are macros. The idea
+   is that you would use these pre-tested macros to solve a
+   very specific set of problems, and they would run fast.
+   Caution: no side-effects in arguments please!! They may be
+   evaluated MANY times!!
+
+   These macros operate a stack of objects.  Each object starts life
+   small, and may grow to maturity.  (Consider building a word syllable
+   by syllable.)  An object can move while it is growing.  Once it has
+   been "finished" it never changes address again.  So the "top of the
+   stack" is typically an immature growing object, while the rest of the
+   stack is of mature, fixed size and fixed address objects.
+
+   These routines grab large chunks of memory, using a function you
+   supply, called 'obstack_chunk_alloc'.  On occasion, they free chunks,
+   by calling 'obstack_chunk_free'.  You must define them and declare
+   them before using any obstack macros.
+
+   Each independent stack is represented by a 'struct obstack'.
+   Each of the obstack macros expects a pointer to such a structure
+   as the first argument.
+
+   One motivation for this package is the problem of growing char strings
+   in symbol tables.  Unless you are "fascist pig with a read-only mind"
+   --Gosper's immortal quote from HAKMEM item 154, out of context--you
+   would not like to put any arbitrary upper limit on the length of your
+   symbols.
+
+   In practice this often means you will build many short symbols and a
+   few long symbols.  At the time you are reading a symbol you don't know
+   how long it is.  One traditional method is to read a symbol into a
+   buffer, realloc()ating the buffer every time you try to read a symbol
+   that is longer than the buffer.  This is beaut, but you still will
+   want to copy the symbol from the buffer to a more permanent
+   symbol-table entry say about half the time.
+
+   With obstacks, you can work differently.  Use one obstack for all symbol
+   names.  As you read a symbol, grow the name in the obstack gradually.
+   When the name is complete, finalize it.  Then, if the symbol exists already,
+   free the newly read name.
+
+   The way we do this is to take a large chunk, allocating memory from
+   low addresses.  When you want to build a symbol in the chunk you just
+   add chars above the current "high water mark" in the chunk.  When you
+   have finished adding chars, because you got to the end of the symbol,
+   you know how long the chars are, and you can create a new object.
+   Mostly the chars will not burst over the highest address of the chunk,
+   because you would typically expect a chunk to be (say) 100 times as
+   long as an average object.
+
+   In case that isn't clear, when we have enough chars to make up
+   the object, THEY ARE ALREADY CONTIGUOUS IN THE CHUNK (guaranteed)
+   so we just point to it where it lies.  No moving of chars is
+   needed and this is the second win: potentially long strings need
+   never be explicitly shuffled. Once an object is formed, it does not
+   change its address during its lifetime.
+
+   When the chars burst over a chunk boundary, we allocate a larger
+   chunk, and then copy the partly formed object from the end of the old
+   chunk to the beginning of the new larger chunk.  We then carry on
+   accreting characters to the end of the object as we normally would.
+
+   A special macro is provided to add a single char at a time to a
+   growing object.  This allows the use of register variables, which
+   break the ordinary 'growth' macro.
+
+   Summary:
+        We allocate large chunks.
+        We carve out one object at a time from the current chunk.
+        Once carved, an object never moves.
+        We are free to append data of any size to the currently
+          growing object.
+        Exactly one object is growing in an obstack at any one time.
+        You can run one obstack per control block.
+        You may have as many control blocks as you dare.
+        Because of the way we do it, you can "unwind" an obstack
+          back to a previous state. (You may remove objects much
+          as you would with a stack.)
+ */
+
+
+/* Don't do the contents of this file more than once.  */
+
+#ifndef _OBSTACK_H
+#define _OBSTACK_H 1
+
+#ifndef _OBSTACK_INTERFACE_VERSION
+# define _OBSTACK_INTERFACE_VERSION 2
+#endif
+
+#include <stddef.h>             /* For size_t and ptrdiff_t.  */
+#include <string.h>             /* For __GNU_LIBRARY__, and memcpy.  */
+
+#if _OBSTACK_INTERFACE_VERSION == 1
+/* For binary compatibility with obstack version 1, which used "int"
+   and "long" for these two types.  */
+# define _OBSTACK_SIZE_T unsigned int
+# define _CHUNK_SIZE_T unsigned long
+# define _OBSTACK_CAST(type, expr) ((type) (expr))
+#else
+/* Version 2 with sane types, especially for 64-bit hosts.  */
+# define _OBSTACK_SIZE_T size_t
+# define _CHUNK_SIZE_T size_t
+# define _OBSTACK_CAST(type, expr) (expr)
+#endif
+
+/* If B is the base of an object addressed by P, return the result of
+   aligning P to the next multiple of A + 1.  B and P must be of type
+   char *.  A + 1 must be a power of 2.  */
+
+#define __BPTR_ALIGN(B, P, A) ((B) + (((P) - (B) + (A)) & ~(A)))
+
+/* Similar to __BPTR_ALIGN (B, P, A), except optimize the common case
+   where pointers can be converted to integers, aligned as integers,
+   and converted back again.  If ptrdiff_t is narrower than a
+   pointer (e.g., the AS/400), play it safe and compute the alignment
+   relative to B.  Otherwise, use the faster strategy of computing the
+   alignment relative to 0.  */
+
+#define __PTR_ALIGN(B, P, A)						      \
+  __BPTR_ALIGN (sizeof (ptrdiff_t) < sizeof (void *) ? (B) : (char *) 0,      \
+                P, A)
+
+#ifndef __attribute_pure__
+# if defined __GNUC_MINOR__ && __GNUC__ * 1000 + __GNUC_MINOR__ >= 2096
+#  define __attribute_pure__ __attribute__ ((__pure__))
+# else
+#  define __attribute_pure__
+# endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct _obstack_chunk           /* Lives at front of each chunk. */
+{
+  char *limit;                  /* 1 past end of this chunk */
+  struct _obstack_chunk *prev;  /* address of prior chunk or NULL */
+  char contents[4];             /* objects begin here */
+};
+
+struct obstack          /* control current object in current chunk */
+{
+  _CHUNK_SIZE_T chunk_size;     /* preferred size to allocate chunks in */
+  struct _obstack_chunk *chunk; /* address of current struct obstack_chunk */
+  char *object_base;            /* address of object we are building */
+  char *next_free;              /* where to add next char to current object */
+  char *chunk_limit;            /* address of char after current chunk */
+  union
+  {
+    _OBSTACK_SIZE_T i;
+    void *p;
+  } temp;                       /* Temporary for some macros.  */
+  _OBSTACK_SIZE_T alignment_mask;  /* Mask of alignment for each object. */
+
+  /* These prototypes vary based on 'use_extra_arg'.  */
+  union
+  {
+    void *(*plain) (size_t);
+    void *(*extra) (void *, size_t);
+  } chunkfun;
+  union
+  {
+    void (*plain) (void *);
+    void (*extra) (void *, void *);
+  } freefun;
+
+  void *extra_arg;              /* first arg for chunk alloc/dealloc funcs */
+  unsigned use_extra_arg : 1;     /* chunk alloc/dealloc funcs take extra arg */
+  unsigned maybe_empty_object : 1; /* There is a possibility that the current
+                                      chunk contains a zero-length object.  This
+                                      prevents freeing the chunk if we allocate
+                                      a bigger chunk to replace it. */
+  unsigned alloc_failed : 1;      /* No longer used, as we now call the failed
+                                     handler on error, but retained for binary
+                                     compatibility.  */
+};
+
+/* Declare the external functions we use; they are in obstack.c.  */
+
+extern void _obstack_newchunk (struct obstack *, _OBSTACK_SIZE_T);
+extern void _obstack_free (struct obstack *, void *);
+extern int _obstack_begin (struct obstack *,
+                           _OBSTACK_SIZE_T, _OBSTACK_SIZE_T,
+                           void *(*) (size_t), void (*) (void *));
+extern int _obstack_begin_1 (struct obstack *,
+                             _OBSTACK_SIZE_T, _OBSTACK_SIZE_T,
+                             void *(*) (void *, size_t),
+                             void (*) (void *, void *), void *);
+extern _OBSTACK_SIZE_T _obstack_memory_used (struct obstack *)
+  __attribute_pure__;
+
+
+/* Error handler called when 'obstack_chunk_alloc' failed to allocate
+   more memory.  This can be set to a user defined function which
+   should either abort gracefully or use longjump - but shouldn't
+   return.  The default action is to print a message and abort.  */
+extern void (*obstack_alloc_failed_handler) (void);
+
+/* Exit value used when 'print_and_abort' is used.  */
+extern int obstack_exit_failure;
+
+/* Pointer to beginning of object being allocated or to be allocated next.
+   Note that this might not be the final address of the object
+   because a new chunk might be needed to hold the final size.  */
+
+#define obstack_base(h) ((void *) (h)->object_base)
+
+/* Size for allocating ordinary chunks.  */
+
+#define obstack_chunk_size(h) ((h)->chunk_size)
+
+/* Pointer to next byte not yet allocated in current chunk.  */
+
+#define obstack_next_free(h) ((void *) (h)->next_free)
+
+/* Mask specifying low bits that should be clear in address of an object.  */
+
+#define obstack_alignment_mask(h) ((h)->alignment_mask)
+
+/* To prevent prototype warnings provide complete argument list.  */
+#define obstack_init(h)							      \
+  _obstack_begin ((h), 0, 0,						      \
+                  _OBSTACK_CAST (void *(*) (size_t), obstack_chunk_alloc),    \
+                  _OBSTACK_CAST (void (*) (void *), obstack_chunk_free))
+
+#define obstack_begin(h, size)						      \
+  _obstack_begin ((h), (size), 0,					      \
+                  _OBSTACK_CAST (void *(*) (size_t), obstack_chunk_alloc), \
+                  _OBSTACK_CAST (void (*) (void *), obstack_chunk_free))
+
+#define obstack_specify_allocation(h, size, alignment, chunkfun, freefun)     \
+  _obstack_begin ((h), (size), (alignment),				      \
+                  _OBSTACK_CAST (void *(*) (size_t), chunkfun),		      \
+                  _OBSTACK_CAST (void (*) (void *), freefun))
+
+#define obstack_specify_allocation_with_arg(h, size, alignment, chunkfun, freefun, arg) \
+  _obstack_begin_1 ((h), (size), (alignment),				      \
+                    _OBSTACK_CAST (void *(*) (void *, size_t), chunkfun),     \
+                    _OBSTACK_CAST (void (*) (void *, void *), freefun), arg)
+
+#define obstack_chunkfun(h, newchunkfun)				      \
+  ((void) ((h)->chunkfun.extra = (void *(*) (void *, size_t)) (newchunkfun)))
+
+#define obstack_freefun(h, newfreefun)					      \
+  ((void) ((h)->freefun.extra = (void *(*) (void *, void *)) (newfreefun)))
+
+#define obstack_1grow_fast(h, achar) ((void) (*((h)->next_free)++ = (achar)))
+
+#define obstack_blank_fast(h, n) ((void) ((h)->next_free += (n)))
+
+#define obstack_memory_used(h) _obstack_memory_used (h)
+
+int obstack_printf(struct obstack *obstack, const char *__restrict fmt, ...);
+
+
+#if defined __GNUC__
+# if !defined __GNUC_MINOR__ || __GNUC__ * 1000 + __GNUC_MINOR__ < 2008
+#  define __extension__
+# endif
+
+/* For GNU C, if not -traditional,
+   we can define these macros to compute all args only once
+   without using a global variable.
+   Also, we can avoid using the 'temp' slot, to make faster code.  */
+
+# define obstack_object_size(OBSTACK)					      \
+  __extension__								      \
+    ({ struct obstack const *__o = (OBSTACK);				      \
+       (_OBSTACK_SIZE_T) (__o->next_free - __o->object_base); })
+
+/* The local variable is named __o1 to avoid a shadowed variable
+   warning when invoked from other obstack macros.  */
+# define obstack_room(OBSTACK)						      \
+  __extension__								      \
+    ({ struct obstack const *__o1 = (OBSTACK);				      \
+       (_OBSTACK_SIZE_T) (__o1->chunk_limit - __o1->next_free); })
+
+# define obstack_make_room(OBSTACK, length)				      \
+  __extension__								      \
+    ({ struct obstack *__o = (OBSTACK);					      \
+       _OBSTACK_SIZE_T __len = (length);				      \
+       if (obstack_room (__o) < __len)					      \
+         _obstack_newchunk (__o, __len);				      \
+       (void) 0; })
+
+# define obstack_empty_p(OBSTACK)					      \
+  __extension__								      \
+    ({ struct obstack const *__o = (OBSTACK);				      \
+       (__o->chunk->prev == 0						      \
+        && __o->next_free == __PTR_ALIGN ((char *) __o->chunk,		      \
+                                          __o->chunk->contents,		      \
+                                          __o->alignment_mask)); })
+
+# define obstack_grow(OBSTACK, where, length)				      \
+  __extension__								      \
+    ({ struct obstack *__o = (OBSTACK);					      \
+       _OBSTACK_SIZE_T __len = (length);				      \
+       if (obstack_room (__o) < __len)					      \
+         _obstack_newchunk (__o, __len);				      \
+       memcpy (__o->next_free, where, __len);				      \
+       __o->next_free += __len;						      \
+       (void) 0; })
+
+# define obstack_grow0(OBSTACK, where, length)				      \
+  __extension__								      \
+    ({ struct obstack *__o = (OBSTACK);					      \
+       _OBSTACK_SIZE_T __len = (length);				      \
+       if (obstack_room (__o) < __len + 1)				      \
+         _obstack_newchunk (__o, __len + 1);				      \
+       memcpy (__o->next_free, where, __len);				      \
+       __o->next_free += __len;						      \
+       *(__o->next_free)++ = 0;						      \
+       (void) 0; })
+
+# define obstack_1grow(OBSTACK, datum)					      \
+  __extension__								      \
+    ({ struct obstack *__o = (OBSTACK);					      \
+       if (obstack_room (__o) < 1)					      \
+         _obstack_newchunk (__o, 1);					      \
+       obstack_1grow_fast (__o, datum); })
+
+/* These assume that the obstack alignment is good enough for pointers
+   or ints, and that the data added so far to the current object
+   shares that much alignment.  */
+
+# define obstack_ptr_grow(OBSTACK, datum)				      \
+  __extension__								      \
+    ({ struct obstack *__o = (OBSTACK);					      \
+       if (obstack_room (__o) < sizeof (void *))			      \
+         _obstack_newchunk (__o, sizeof (void *));			      \
+       obstack_ptr_grow_fast (__o, datum); })
+
+# define obstack_int_grow(OBSTACK, datum)				      \
+  __extension__								      \
+    ({ struct obstack *__o = (OBSTACK);					      \
+       if (obstack_room (__o) < sizeof (int))				      \
+         _obstack_newchunk (__o, sizeof (int));				      \
+       obstack_int_grow_fast (__o, datum); })
+
+# define obstack_ptr_grow_fast(OBSTACK, aptr)				      \
+  __extension__								      \
+    ({ struct obstack *__o1 = (OBSTACK);				      \
+       void *__p1 = __o1->next_free;					      \
+       *(const void **) __p1 = (aptr);					      \
+       __o1->next_free += sizeof (const void *);			      \
+       (void) 0; })
+
+# define obstack_int_grow_fast(OBSTACK, aint)				      \
+  __extension__								      \
+    ({ struct obstack *__o1 = (OBSTACK);				      \
+       void *__p1 = __o1->next_free;					      \
+       *(int *) __p1 = (aint);						      \
+       __o1->next_free += sizeof (int);					      \
+       (void) 0; })
+
+# define obstack_blank(OBSTACK, length)					      \
+  __extension__								      \
+    ({ struct obstack *__o = (OBSTACK);					      \
+       _OBSTACK_SIZE_T __len = (length);				      \
+       if (obstack_room (__o) < __len)					      \
+         _obstack_newchunk (__o, __len);				      \
+       obstack_blank_fast (__o, __len); })
+
+# define obstack_alloc(OBSTACK, length)					      \
+  __extension__								      \
+    ({ struct obstack *__h = (OBSTACK);					      \
+       obstack_blank (__h, (length));					      \
+       obstack_finish (__h); })
+
+# define obstack_copy(OBSTACK, where, length)				      \
+  __extension__								      \
+    ({ struct obstack *__h = (OBSTACK);					      \
+       obstack_grow (__h, (where), (length));				      \
+       obstack_finish (__h); })
+
+# define obstack_copy0(OBSTACK, where, length)				      \
+  __extension__								      \
+    ({ struct obstack *__h = (OBSTACK);					      \
+       obstack_grow0 (__h, (where), (length));				      \
+       obstack_finish (__h); })
+
+/* The local variable is named __o1 to avoid a shadowed variable
+   warning when invoked from other obstack macros, typically obstack_free.  */
+# define obstack_finish(OBSTACK)					      \
+  __extension__								      \
+    ({ struct obstack *__o1 = (OBSTACK);				      \
+       void *__value = (void *) __o1->object_base;			      \
+       if (__o1->next_free == __value)					      \
+         __o1->maybe_empty_object = 1;					      \
+       __o1->next_free							      \
+         = __PTR_ALIGN (__o1->object_base, __o1->next_free,		      \
+                        __o1->alignment_mask);				      \
+       if ((size_t) (__o1->next_free - (char *) __o1->chunk)		      \
+           > (size_t) (__o1->chunk_limit - (char *) __o1->chunk))	      \
+         __o1->next_free = __o1->chunk_limit;				      \
+       __o1->object_base = __o1->next_free;				      \
+       __value; })
+
+# define obstack_free(OBSTACK, OBJ)					      \
+  __extension__								      \
+    ({ struct obstack *__o = (OBSTACK);					      \
+       void *__obj = (void *) (OBJ);					      \
+       if (__obj > (void *) __o->chunk && __obj < (void *) __o->chunk_limit)  \
+         __o->next_free = __o->object_base = (char *) __obj;		      \
+       else								      \
+         _obstack_free (__o, __obj); })
+
+#else /* not __GNUC__ */
+
+# define obstack_object_size(h)						      \
+  ((_OBSTACK_SIZE_T) ((h)->next_free - (h)->object_base))
+
+# define obstack_room(h)						      \
+  ((_OBSTACK_SIZE_T) ((h)->chunk_limit - (h)->next_free))
+
+# define obstack_empty_p(h)						      \
+  ((h)->chunk->prev == 0						      \
+   && (h)->next_free == __PTR_ALIGN ((char *) (h)->chunk,		      \
+                                     (h)->chunk->contents,		      \
+                                     (h)->alignment_mask))
+
+/* Note that the call to _obstack_newchunk is enclosed in (..., 0)
+   so that we can avoid having void expressions
+   in the arms of the conditional expression.
+   Casting the third operand to void was tried before,
+   but some compilers won't accept it.  */
+
+# define obstack_make_room(h, length)					      \
+  ((h)->temp.i = (length),						      \
+   ((obstack_room (h) < (h)->temp.i)					      \
+    ? (_obstack_newchunk (h, (h)->temp.i), 0) : 0),			      \
+   (void) 0)
+
+# define obstack_grow(h, where, length)					      \
+  ((h)->temp.i = (length),						      \
+   ((obstack_room (h) < (h)->temp.i)					      \
+   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   memcpy ((h)->next_free, where, (h)->temp.i),				      \
+   (h)->next_free += (h)->temp.i,					      \
+   (void) 0)
+
+# define obstack_grow0(h, where, length)				      \
+  ((h)->temp.i = (length),						      \
+   ((obstack_room (h) < (h)->temp.i + 1)				      \
+   ? (_obstack_newchunk ((h), (h)->temp.i + 1), 0) : 0),		      \
+   memcpy ((h)->next_free, where, (h)->temp.i),				      \
+   (h)->next_free += (h)->temp.i,					      \
+   *((h)->next_free)++ = 0,						      \
+   (void) 0)
+
+# define obstack_1grow(h, datum)					      \
+  (((obstack_room (h) < 1)						      \
+    ? (_obstack_newchunk ((h), 1), 0) : 0),				      \
+   obstack_1grow_fast (h, datum))
+
+# define obstack_ptr_grow(h, datum)					      \
+  (((obstack_room (h) < sizeof (char *))				      \
+    ? (_obstack_newchunk ((h), sizeof (char *)), 0) : 0),		      \
+   obstack_ptr_grow_fast (h, datum))
+
+# define obstack_int_grow(h, datum)					      \
+  (((obstack_room (h) < sizeof (int))					      \
+    ? (_obstack_newchunk ((h), sizeof (int)), 0) : 0),			      \
+   obstack_int_grow_fast (h, datum))
+
+# define obstack_ptr_grow_fast(h, aptr)					      \
+  (((const void **) ((h)->next_free += sizeof (void *)))[-1] = (aptr),	      \
+   (void) 0)
+
+# define obstack_int_grow_fast(h, aint)					      \
+  (((int *) ((h)->next_free += sizeof (int)))[-1] = (aint),		      \
+   (void) 0)
+
+# define obstack_blank(h, length)					      \
+  ((h)->temp.i = (length),						      \
+   ((obstack_room (h) < (h)->temp.i)					      \
+   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   obstack_blank_fast (h, (h)->temp.i))
+
+# define obstack_alloc(h, length)					      \
+  (obstack_blank ((h), (length)), obstack_finish ((h)))
+
+# define obstack_copy(h, where, length)					      \
+  (obstack_grow ((h), (where), (length)), obstack_finish ((h)))
+
+# define obstack_copy0(h, where, length)				      \
+  (obstack_grow0 ((h), (where), (length)), obstack_finish ((h)))
+
+# define obstack_finish(h)						      \
+  (((h)->next_free == (h)->object_base					      \
+    ? (((h)->maybe_empty_object = 1), 0)				      \
+    : 0),								      \
+   (h)->temp.p = (h)->object_base,					      \
+   (h)->next_free							      \
+     = __PTR_ALIGN ((h)->object_base, (h)->next_free,			      \
+                    (h)->alignment_mask),				      \
+   (((size_t) ((h)->next_free - (char *) (h)->chunk)			      \
+     > (size_t) ((h)->chunk_limit - (char *) (h)->chunk))		      \
+   ? ((h)->next_free = (h)->chunk_limit) : 0),				      \
+   (h)->object_base = (h)->next_free,					      \
+   (h)->temp.p)
+
+# define obstack_free(h, obj)						      \
+  ((h)->temp.p = (void *) (obj),					      \
+   (((h)->temp.p > (void *) (h)->chunk					      \
+     && (h)->temp.p < (void *) (h)->chunk_limit)			      \
+    ? (void) ((h)->next_free = (h)->object_base = (char *) (h)->temp.p)       \
+    : _obstack_free ((h), (h)->temp.p)))
+
+#endif /* not __GNUC__ */
+
+#ifdef __cplusplus
+}       /* C++ */
+#endif
+
+#endif /* _OBSTACK_H */

--- a/obstack_printf.c
+++ b/obstack_printf.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <strings.h>
+#include "obstack.h"
+
+int obstack_printf(struct obstack *obstack, const char *__restrict fmt, ...)
+{
+	char buf[1024];
+	va_list ap;
+	int len;
+
+	va_start(ap, fmt);
+	len = vsnprintf(buf, sizeof(buf), fmt, ap);
+	obstack_grow(obstack, buf, len);
+	va_end(ap);
+
+	return len;
+}

--- a/os/Cygwin.c
+++ b/os/Cygwin.c
@@ -15,7 +15,7 @@
 #include <sys/types.h>
 #include <sys/vfs.h>    /* statfs */
 /* glibc only goodness */
-#include <obstack.h>    /* glibc's handy obstacks */
+#include "obstack.h"    /* glibc's handy obstacks */
 /* pthreads */
 #include <pthread.h>    /* pthread_once */
 

--- a/os/Cygwin.c
+++ b/os/Cygwin.c
@@ -1,5 +1,5 @@
 #ifndef _GNU_SOURCE
-    #define _GNU_SOURCE     /* for canonicalize_file_name */
+    #define _GNU_SOURCE    /* for canonicalize_file_name */
 #endif
 
 #include <ctype.h>      /* is_digit */
@@ -19,23 +19,23 @@
 /* pthreads */
 #include <pthread.h>    /* pthread_once */
 
-#define obstack_chunk_alloc     malloc
-#define obstack_chunk_free      free
+#define obstack_chunk_alloc    malloc
+#define obstack_chunk_free     free
 
 #include "os/Cygwin.h"
 
 /* NOTE: Before this was actually milliseconds even though it said microseconds, now it is correct. */
-#define JIFFIES_TO_MICROSECONDS(x) (((x)*1e6)/system_hertz)
+#define JIFFIES_TO_MICROSECONDS(x)    (((x) * 1e6) / system_hertz)
 
 /* some static values that won't change, */
-static pthread_once_t   globals_init = PTHREAD_ONCE_INIT;
+static pthread_once_t globals_init = PTHREAD_ONCE_INIT;
 
-static long long            boot_time;
-static unsigned             page_size;
-static unsigned long long   system_memory;
-static unsigned             system_hertz;
+static long long          boot_time;
+static unsigned           page_size;
+static unsigned long long system_memory;
+static unsigned           system_hertz;
 
-static bool     init_failed = false;
+static bool init_failed = false;
 
 
 /* get_string()
@@ -56,14 +56,14 @@ inline static const char *get_string(int elem)
  */
 static void init_static_vars()
 {
-  struct obstack      mem_pool;
+  struct obstack mem_pool;
 
-  char                *file_text, *file_off;
-  off_t               file_len;
+  char *file_text, *file_off;
+  off_t file_len;
 
-  unsigned long long  total_memory;
+  unsigned long long total_memory;
 
-  boot_time = -1;
+  boot_time     = -1;
   system_memory = -1;
 
   page_size = getpagesize();
@@ -76,42 +76,48 @@ static void init_static_vars()
 
   /* find boot time */
   /* read /proc/stat in */
-  if ((file_text = read_file("stat", NULL, &file_len, &mem_pool)) == NULL)
+  if((file_text = read_file("stat", NULL, &file_len, &mem_pool)) == NULL) {
     goto fail;
+  }
 
   /* look for the line that starts with btime
-   * NOTE: incrementing file_off after strchr is legal because file_text will
-   *       be null terminated, so worst case after '\n' there will be '\0' and
-   *       strncmp will fail or sscanf won't return 1
-   *       Only increment on the first line */
-  for (file_off = file_text; file_off; file_off = strchr(file_off, '\n')) {
-    if (file_off != file_text)
+  * NOTE: incrementing file_off after strchr is legal because file_text will
+  *       be null terminated, so worst case after '\n' there will be '\0' and
+  *       strncmp will fail or sscanf won't return 1
+  *       Only increment on the first line */
+  for(file_off = file_text; file_off; file_off = strchr(file_off, '\n')) {
+    if(file_off != file_text) {
       file_off++;
+    }
 
-    if (strncmp(file_off, "btime", 5) == 0) {
-      if (sscanf(file_off, "btime %lld", &boot_time) == 1)
+    if(strncmp(file_off, "btime", 5) == 0) {
+      if(sscanf(file_off, "btime %lld", &boot_time) == 1) {
         break;
+      }
     }
   }
 
   obstack_free(&mem_pool, file_text);
 
   /* did we scrape the number of pages successfuly? */
-  if (boot_time == -1)
+  if(boot_time == -1) {
     goto fail;
+  }
 
   /* find total number of system pages */
   /* read /proc/meminfo */
-  if ((file_text = read_file("meminfo", NULL, &file_len, &mem_pool)) == NULL)
+  if((file_text = read_file("meminfo", NULL, &file_len, &mem_pool)) == NULL) {
     goto fail;
+  }
 
   /* look for the line that starts with: MemTotal */
-  for (file_off = file_text; file_off; file_off = strchr(file_off, '\n')) {
-    if (file_off != file_text)
+  for(file_off = file_text; file_off; file_off = strchr(file_off, '\n')) {
+    if(file_off != file_text) {
       file_off++;
+    }
 
-    if (strncmp(file_off, "MemTotal:", 9) == 0) {
-      if (sscanf(file_off, "MemTotal: %llu", &system_memory) == 1) {
+    if(strncmp(file_off, "MemTotal:", 9) == 0) {
+      if(sscanf(file_off, "MemTotal: %llu", &system_memory) == 1) {
         system_memory *= 1024; /* convert to bytes */
         break;
       }
@@ -123,8 +129,9 @@ static void init_static_vars()
   /* did we scrape the number of pages successfuly? */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-  if (total_memory == -1)
+  if(total_memory == -1) {
     goto fail;
+  }
 #pragma GCC diagnostic pop
 
   /* initialize system hertz value */
@@ -134,11 +141,10 @@ static void init_static_vars()
   return;
 
   /* mark failure and cleanup allocated resources */
- fail:
+fail:
   obstack_free(&mem_pool, NULL);
   init_failed = true;
 }
-
 
 /* OS_initialize()
  *
@@ -147,20 +153,22 @@ static void init_static_vars()
  * NOTE: There's a const char* -> char* conversion that's evil, but can't fix
  * this without breaking the Proc::ProcessTable XS API.
  */
-char* OS_initialize()
+char *OS_initialize()
 {
   struct statfs sfs;
 
   /* did we already try to initilize before and fail, if pthrad_once only
    * let us flag a failure from the init function; behavor of longjmp is
    * undefined, so that avaue is out out of the question */
-  if (init_failed)
-    return (char *) get_string(STR_ERR_INIT);
+  if(init_failed) {
+    return (char *)get_string(STR_ERR_INIT);
+  }
 
   /* check if /proc is mounted, let this go before initializing globals (below),
    * since the missing /proc message might me helpful */
-  if(statfs("/proc", &sfs) == -1)
-    return (char *) get_string(STR_ERR_PROC_STATFS);
+  if(statfs("/proc", &sfs) == -1) {
+    return (char *)get_string(STR_ERR_PROC_STATFS);
+  }
 
   /* one time initialization of some values that won't change */
   pthread_once(&globals_init, init_static_vars);
@@ -168,20 +176,19 @@ char* OS_initialize()
   return NULL;
 }
 
-
-
 inline static void field_enable(char *format_str, enum field field)
 {
   format_str[field] = tolower(format_str[field]);
 }
 
-
 inline static void field_enable_range(char *format_str, enum field field1,
                                       enum field field2)
 {
   int i;
-  for (i = field1; i <= field2; i++)
+
+  for(i = field1; i <= field2; i++) {
     format_str[i] = tolower(format_str[i]);
+  }
 }
 
 /* proc_pid_file()
@@ -198,14 +205,14 @@ inline static char *proc_pid_file(const char *pid, const char *file,
   obstack_printf(mem_pool, "/proc/%s", pid);
 
   /* additional path (not just the dir) */
-  if (file)
+  if(file) {
     obstack_printf(mem_pool, "/%s", file);
+  }
 
   obstack_1grow(mem_pool, '\0');
 
-  return (char *) obstack_finish(mem_pool);
+  return (char *)obstack_finish(mem_pool);
 }
-
 
 /* read_file()
  *
@@ -223,8 +230,8 @@ inline static char *proc_pid_file(const char *pid, const char *file,
 static char *read_file(const char *path, const char *extra_path,
                        off_t *len, struct obstack *mem_pool)
 {
-  int         fd, result = -1;
-  char        *text, *file, *start;
+  int   fd, result = -1;
+  char *text, *file, *start;
 
   /* build the filename in our tempoary storage */
   file = proc_pid_file(path, extra_path, mem_pool);
@@ -235,22 +242,23 @@ static char *read_file(const char *path, const char *extra_path,
    * poluting the obstack and the only thing left on it is the file */
   obstack_free(mem_pool, file);
 
-  if (fd == -1)
+  if(fd == -1) {
     return NULL;
+  }
 
   /* read file into our buffer */
-  for (*len = 0; result; *len += result) {
+  for(*len = 0; result; *len += result) {
     obstack_blank(mem_pool, 1024);
     start = obstack_base(mem_pool) + *len;
 
-    if ((result = read(fd, start, 1024)) == -1) {
+    if((result = read(fd, start, 1024)) == -1) {
       obstack_free(mem_pool, obstack_finish(mem_pool));
       close(fd);
       return NULL;
     }
   }
 
-  start = obstack_base(mem_pool) + *len;
+  start  = obstack_base(mem_pool) + *len;
   *start = '\0';
 
   /* finalize our text buffer */
@@ -271,10 +279,10 @@ static char *read_file(const char *path, const char *extra_path,
  * @param   prs         Data structure where to put the scraped values
  * @param   mem_pool    Obstack to use for temory storage
  */
-static void get_user_info(char *pid, char *format_str, struct procstat* prs,
+static void get_user_info(char *pid, char *format_str, struct procstat *prs,
                           struct obstack *mem_pool)
 {
-  char        *path_pid;
+  char *      path_pid;
   struct stat stat_pid;
   int         result;
 
@@ -285,8 +293,9 @@ static void get_user_info(char *pid, char *format_str, struct procstat* prs,
 
   obstack_free(mem_pool, path_pid);
 
-  if (result == -1)
+  if(result == -1) {
     return;
+  }
 
   prs->uid = stat_pid.st_uid;
   prs->gid = stat_pid.st_gid;
@@ -304,42 +313,43 @@ static void get_user_info(char *pid, char *format_str, struct procstat* prs,
  * @param   prs         Data structure where to put the scraped values
  * @param   mem_pool    Obstack to use for temory storage
  */
-static bool get_proc_stat(char *pid, char *format_str, struct procstat* prs,
+static bool get_proc_stat(char *pid, char *format_str, struct procstat *prs,
                           struct obstack *mem_pool)
 {
-  char    *stat_text, *stat_cont, *close_paren, *open_paren;
-  int     result;
-  off_t   stat_len;
-  long    dummy_l;
-  int     dummy_i;
+  char *stat_text, *stat_cont, *close_paren, *open_paren;
+  int   result;
+  off_t stat_len;
+  long  dummy_l;
+  int   dummy_i;
 
-  bool    read_ok = true;
+  bool read_ok = true;
 
-  if ((stat_text = read_file(pid, "stat", &stat_len, mem_pool)) == NULL) {
+  if((stat_text = read_file(pid, "stat", &stat_len, mem_pool)) == NULL) {
     return false;
   }
 
-  if (sscanf(stat_text, "%d (", &prs->pid) != 1) {
+  if(sscanf(stat_text, "%d (", &prs->pid) != 1) {
     goto done;
   }
 
   /* replace the first ')' with a '\0', the contents look like this:
    *    pid (program_name) state ...
    * if we don't find ')' then it's incorrectly formated */
-  if ((close_paren = strrchr(stat_text, ')')) == NULL) {
+  if((close_paren = strrchr(stat_text, ')')) == NULL) {
     read_ok = false;
     goto done;
   }
   *close_paren = '\0';
 
-  if ((open_paren = strchr(stat_text, '(')) == NULL) {
+  if((open_paren = strchr(stat_text, '(')) == NULL) {
     read_ok = false;
     goto done;
   }
 
 
   int comm_esize = sizeof(prs->comm) - 1;
-  int comm_len = close_paren - open_paren - 1;
+  int comm_len   = close_paren - open_paren - 1;
+
   if(comm_len > comm_esize) {
     comm_len = comm_esize;
   }
@@ -356,37 +366,37 @@ static bool get_proc_stat(char *pid, char *format_str, struct procstat* prs,
 
   /* scrape the remaining values */
   result = sscanf(stat_cont,
-                  " %c"   /*  3 state*/
-                  " %d"   /*  4 ppid */
-                  " %d"   /*  5 pgrp */
-                  " %d"   /*  6 sid  */
-                  " %d"   /*  7 tty */
-                  " %d"   /*  8 tty_pgid */
-                  " %u"   /*  9 flags */
-                  " %lu"  /* 10 minflt */
-                  " %lu"  /* 11 cminflt */
-                  " %lu"  /* 12 majflt */
-                  " %lu"  /* 13 cmajflt */
-                  " %llu" /* 14 utime */
-                  " %llu" /* 15 stime */
-                  " %lld"  /* 16 cutime */
-                  " %lld"  /* 17 cstime */
-                  " %ld"  /* 18 priority */
-                  " %ld"  /* 19 nice */
-                  " %ld"  /* 20 num_threads */
-                  " %d"   /* 21 itrealvalue */
-                  " %llu" /* 22 starttime */
-                  " %lu"  /* 23 vsize */
-                  " %ld"  /* 24 rss */
-                  " %ld"  /* 25 rsslim */
+                  " %c"                        /*  3 state*/
+                  " %d"                        /*  4 ppid */
+                  " %d"                        /*  5 pgrp */
+                  " %d"                        /*  6 sid  */
+                  " %d"                        /*  7 tty */
+                  " %d"                        /*  8 tty_pgid */
+                  " %u"                        /*  9 flags */
+                  " %lu"                       /* 10 minflt */
+                  " %lu"                       /* 11 cminflt */
+                  " %lu"                       /* 12 majflt */
+                  " %lu"                       /* 13 cmajflt */
+                  " %llu"                      /* 14 utime */
+                  " %llu"                      /* 15 stime */
+                  " %lld"                      /* 16 cutime */
+                  " %lld"                      /* 17 cstime */
+                  " %ld"                       /* 18 priority */
+                  " %ld"                       /* 19 nice */
+                  " %ld"                       /* 20 num_threads */
+                  " %d"                        /* 21 itrealvalue */
+                  " %llu"                      /* 22 starttime */
+                  " %lu"                       /* 23 vsize */
+                  " %ld"                       /* 24 rss */
+                  " %ld"                       /* 25 rsslim */
                   ,
-                  &prs->state_c,                  /* %c */
-                  &prs->ppid, &prs->pgrp,         /* %d %d */
-                  &prs->sid,                      /* %d */
-                  &prs->tty, &dummy_i,            /* tty, tty_pgid */
-                  &prs->flags,                    /* %u */
+                  &prs->state_c,               /* %c */
+                  &prs->ppid, &prs->pgrp,      /* %d %d */
+                  &prs->sid,                   /* %d */
+                  &prs->tty, &dummy_i,         /* tty, tty_pgid */
+                  &prs->flags,                 /* %u */
                   &prs->minflt, &prs->cminflt,
-                  &prs->majflt, &prs->cmajflt,    /* %lu %lu %lu %lu */
+                  &prs->majflt, &prs->cmajflt, /* %lu %lu %lu %lu */
                   &prs->utime, &prs->stime,
                   &prs->cutime, &prs->cstime,
                   &prs->priority,
@@ -398,7 +408,7 @@ static bool get_proc_stat(char *pid, char *format_str, struct procstat* prs,
                   &dummy_l);
 
   /* 23 items in scanf's list... It's all or nothing baby */
-  if (result != 23) {
+  if(result != 23) {
     read_ok = false;
     goto done;
   }
@@ -410,7 +420,6 @@ done:
   obstack_free(mem_pool, stat_text);
   return read_ok;
 }
-
 
 static void eval_link(char *pid, char *link_rel, enum field field, char **ptr,
                       char *format_str, struct obstack *mem_pool)
@@ -430,108 +439,116 @@ static void eval_link(char *pid, char *link_rel, enum field field, char **ptr,
   /* we no longer need need the path to the link file */
   obstack_free(mem_pool, link_file);
 
-  if (link == NULL)
+  if(link == NULL) {
     return;
+  }
 
   /* copy the path onto our obstack, set the value (somewhere in pts)
    * and free the results of canonicalize_file_name */
   obstack_printf(mem_pool, "%s", link);
   obstack_1grow(mem_pool, '\0');
 
-  *ptr = (char *) obstack_finish(mem_pool);
+  *ptr = (char *)obstack_finish(mem_pool);
   free(link);
 
   /* enable whatever field we successfuly retrived */
   field_enable(format_str, field);
 }
 
-
-static void get_proc_cmndline(char *pid, char *format_str, struct procstat* prs,
+static void get_proc_cmndline(char *pid, char *format_str, struct procstat *prs,
                               struct obstack *mem_pool)
 {
-  char    *cmndline_text, *cur;
-  off_t   cmndline_off;
+  char *cmndline_text, *cur;
+  off_t cmndline_off;
 
-  if ((cmndline_text = read_file(pid, "cmdline", &cmndline_off, mem_pool)) == NULL)
+  if((cmndline_text = read_file(pid, "cmdline", &cmndline_off, mem_pool)) == NULL) {
     return;
+  }
 
   /* replace all '\0' with spaces (except for the last one */
-  for (cur = cmndline_text; cur < cmndline_text + cmndline_off - 1; cur++) {
-    if (*cur == '\0')
+  for(cur = cmndline_text; cur < cmndline_text + cmndline_off - 1; cur++) {
+    if(*cur == '\0') {
       *cur = ' ';
+    }
   }
 
   prs->cmndline = cmndline_text;
   field_enable(format_str, F_CMNDLINE);
 }
 
-static void get_proc_cmdline(char *pid, char *format_str, struct procstat* prs,
+static void get_proc_cmdline(char *pid, char *format_str, struct procstat *prs,
                              struct obstack *mem_pool)
 {
-  char    *cmdline_text;
-  off_t   cmdline_off;
+  char *cmdline_text;
+  off_t cmdline_off;
 
-  if ((cmdline_text = read_file(pid, "cmdline", &cmdline_off, mem_pool)) == NULL)
+  if((cmdline_text = read_file(pid, "cmdline", &cmdline_off, mem_pool)) == NULL) {
     return;
+  }
 
-  prs->cmdline = cmdline_text;
+  prs->cmdline     = cmdline_text;
   prs->cmdline_len = cmdline_off;
   field_enable(format_str, F_CMDLINE);
 }
 
-static void get_proc_environ(char *pid, char *format_str, struct procstat* prs,
+static void get_proc_environ(char *pid, char *format_str, struct procstat *prs,
                              struct obstack *mem_pool)
 {
-  char    *environ_text;
-  off_t   environ_off;
+  char *environ_text;
+  off_t environ_off;
 
-  if ((environ_text = read_file(pid, "environ", &environ_off, mem_pool)) == NULL)
+  if((environ_text = read_file(pid, "environ", &environ_off, mem_pool)) == NULL) {
     return;
+  }
 
-  prs->environ = environ_text;
+  prs->environ     = environ_text;
   prs->environ_len = environ_off;
   field_enable(format_str, F_ENVIRON);
 }
 
-static void get_proc_winexename(char *pid, char *format_str, struct procstat* prs,
+static void get_proc_winexename(char *pid, char *format_str, struct procstat *prs,
                                 struct obstack *mem_pool)
 {
-  char    *winexename_text;
-  off_t   winexename_len;
+  char *winexename_text;
+  off_t winexename_len;
 
-  if ((winexename_text = read_file(pid, "winexename", &winexename_len, mem_pool)) == NULL)
+  if((winexename_text = read_file(pid, "winexename", &winexename_len, mem_pool)) == NULL) {
     return;
+  }
 
   prs->winexename = winexename_text;
   field_enable(format_str, F_WINEXENAME);
 }
 
-static void get_proc_winpid(char *pid, char *format_str, struct procstat* prs,
+static void get_proc_winpid(char *pid, char *format_str, struct procstat *prs,
                             struct obstack *mem_pool)
 {
-  char    *winpid_text;
-  off_t   winpid_len;
-  int     res;
+  char *winpid_text;
+  off_t winpid_len;
+  int   res;
 
-  if ((winpid_text = read_file(pid, "winpid", &winpid_len, mem_pool)) == NULL)
+  if((winpid_text = read_file(pid, "winpid", &winpid_len, mem_pool)) == NULL) {
     return;
+  }
 
-  res = sscanf( winpid_text, "%d", &prs->winpid );
-  if (res == 1)
+  res = sscanf(winpid_text, "%d", &prs->winpid);
+  if(res == 1) {
     field_enable(format_str, F_WINPID);
+  }
 
   obstack_free(mem_pool, winpid_text);
 }
 
-static void get_proc_status(char *pid, char *format_str, struct procstat* prs,
+static void get_proc_status(char *pid, char *format_str, struct procstat *prs,
                             struct obstack *mem_pool)
 {
-  char    *status_text, *loc;
-  off_t   status_len;
-  int     dummy_i;
+  char *status_text, *loc;
+  off_t status_len;
+  int   dummy_i;
 
-  if ((status_text = read_file(pid, "status", &status_len, mem_pool)) == NULL)
+  if((status_text = read_file(pid, "status", &status_len, mem_pool)) == NULL) {
     return;
+  }
 
   loc = status_text;
 
@@ -545,26 +562,27 @@ static void get_proc_status(char *pid, char *format_str, struct procstat* prs,
 
   for(loc = status_text; loc; loc = strchr(loc, '\n')) {
     /* skip past the \n character */
-    if (loc != status_text)
+    if(loc != status_text) {
       loc++;
+    }
 
-    if (strncmp(loc, "Uid:", 4) == 0) {
+    if(strncmp(loc, "Uid:", 4) == 0) {
       sscanf(loc + 4, " %d %d %d %d", &dummy_i, &prs->euid, &prs->suid, &prs->fuid);
       field_enable_range(format_str, F_EUID, F_FUID);
-    } else if (strncmp(loc, "Gid:", 4) == 0) {
+    } else if(strncmp(loc, "Gid:", 4) == 0) {
       sscanf(loc + 4, " %d %d %d %d", &dummy_i, &prs->egid, &prs->sgid, &prs->fgid);
       field_enable_range(format_str, F_EGID, F_FGID);
     }
 
     /* short circuit condition */
-    if (islower((int)format_str[F_EUID]) && islower((int)format_str[F_EGID]))
+    if(islower((int)format_str[F_EUID]) && islower((int)format_str[F_EGID])) {
       goto done;
+    }
   }
 
- done:
+done:
   obstack_free(mem_pool, status_text);
 }
-
 
 /* fixup_stat_values()
  *
@@ -573,53 +591,58 @@ static void get_proc_status(char *pid, char *format_str, struct procstat* prs,
  * @param   format_str  String containing field index types
  * @param   prs         Data structure to peform fixups on
  */
-static void fixup_stat_values(char *format_str, struct procstat* prs)
+static void fixup_stat_values(char *format_str, struct procstat *prs)
 {
   /* set the state pointer to the right (const) string */
-  switch (prs->state_c) {
+  switch(prs->state_c) {
   case 'S':
     prs->state = get_string(SLEEP);
     break;
+
   case 'O':
   case 'R':
     prs->state = get_string(RUN);
     break;
+
   case 'Z':
     prs->state = get_string(DEFUNCT);
     break;
+
   case 'D':
     prs->state = get_string(UWAIT);
     break;
+
   case 'T':
     prs->state = get_string(STOP);
     break;
-    /* unknown state, state is already set to NULL */
+
+  /* unknown state, state is already set to NULL */
   default:
-    ppt_warn("Ran into unknown state (hex char: %x)", (int) prs->state_c);
+    ppt_warn("Ran into unknown state (hex char: %x)", (int)prs->state_c);
     goto skip_state_format;
   }
 
   field_enable(format_str, F_STATE);
 
- skip_state_format:
+skip_state_format:
 
   prs->start_time = (prs->start_time / system_hertz) + boot_time;
 
   /* fix time */
 
-  prs->stime      = JIFFIES_TO_MICROSECONDS(prs->stime);
-  prs->utime      = JIFFIES_TO_MICROSECONDS(prs->utime);
-  prs->cstime     = JIFFIES_TO_MICROSECONDS(prs->cstime);
-  prs->cutime     = JIFFIES_TO_MICROSECONDS(prs->cutime);
+  prs->stime  = JIFFIES_TO_MICROSECONDS(prs->stime);
+  prs->utime  = JIFFIES_TO_MICROSECONDS(prs->utime);
+  prs->cstime = JIFFIES_TO_MICROSECONDS(prs->cstime);
+  prs->cutime = JIFFIES_TO_MICROSECONDS(prs->cutime);
 
   /* derived time values */
-  prs->time   = prs->utime    + prs->stime;
-  prs->ctime  = prs->cutime   + prs->cstime;
+  prs->time  = prs->utime + prs->stime;
+  prs->ctime = prs->cutime + prs->cstime;
 
   field_enable_range(format_str, F_TIME, F_CTIME);
 
   /* fix rss to be in bytes (returned from kernel in pages) */
-  prs->rss    *= page_size;
+  prs->rss *= page_size;
 }
 
 /* calc_prec()
@@ -629,21 +652,24 @@ static void fixup_stat_values(char *format_str, struct procstat* prs)
 static void calc_prec(char *format_str, struct procstat *prs, struct obstack *mem_pool)
 {
   int len;
-  /* calculate pctcpu - NOTE: This assumes the cpu time is in microsecond units!
-     multiplying by 1/1e6 puts all units back in seconds.  Then multiply by 100.0f to get a percentage.
-  */
 
-  float pctcpu = ( 100.0f * (prs->utime + prs->stime ) * 1/1e6 ) / (time(NULL) - prs->start_time);
+  /* calculate pctcpu - NOTE: This assumes the cpu time is in microsecond units!
+   * multiplying by 1/1e6 puts all units back in seconds.  Then multiply by 100.0f to get a percentage.
+   */
+
+  float pctcpu = (100.0f * (prs->utime + prs->stime) * 1 / 1e6) / (time(NULL) - prs->start_time);
 
   len = snprintf(prs->pctcpu, LENGTH_PCTCPU, "%6.2f", pctcpu);
-  if( len >= LENGTH_PCTCPU ) {  ppt_warn("percent cpu truncated from %d, set LENGTH_PCTCPU to at least: %d)", len, len + 1); }
+  if(len >= LENGTH_PCTCPU) {
+    ppt_warn("percent cpu truncated from %d, set LENGTH_PCTCPU to at least: %d)", len, len + 1);
+  }
 
 
   field_enable(format_str, F_PCTCPU);
 
   /* calculate pctmem */
-  if (system_memory > 0) {
-    sprintf(prs->pctmem, "%3.2f", (float) prs->rss / system_memory * 100.f);
+  if(system_memory > 0) {
+    sprintf(prs->pctmem, "%3.2f", (float)prs->rss / system_memory * 100.f);
     field_enable(format_str, F_PCTMEM);
   }
 }
@@ -653,11 +679,12 @@ static void calc_prec(char *format_str, struct procstat *prs, struct obstack *me
  *
  * @return  Boolean value.
  */
-inline static bool is_pid(const char* str)
+inline static bool is_pid(const char *str)
 {
   for(; *str; str++) {
-    if (!isdigit((int)*str))
+    if(!isdigit((int)*str)) {
       return false;
+    }
   }
 
   return true;
@@ -665,8 +692,8 @@ inline static bool is_pid(const char* str)
 
 inline static bool pid_exists(const char *str, struct obstack *mem_pool)
 {
-  char    *pid_dir_path = NULL;
-  int     result;
+  char *pid_dir_path = NULL;
+  int   result;
 
   obstack_printf(mem_pool, "/proc/%s", str);
   obstack_1grow(mem_pool, '\0');
@@ -683,18 +710,18 @@ inline static bool pid_exists(const char *str, struct obstack *mem_pool)
 void OS_get_table()
 {
   /* dir walker storage */
-  DIR             *dir;
-  struct dirent   *dir_ent, *dir_result;
+  DIR *          dir;
+  struct dirent *dir_ent, *dir_result;
 
   /* all our storage is going to be here */
-  struct obstack  mem_pool;
+  struct obstack mem_pool;
 
   /* container for scraped process values */
   struct procstat *prs;
 
   /* string containing our local copy of format_str, elements will be
    * lower cased if we are able to figure them out */
-  char            *format_str;
+  char *format_str;
 
   /* initialize a small memory pool for this function */
   obstack_init(&mem_pool);
@@ -702,15 +729,16 @@ void OS_get_table()
   /* put the dirent on the obstack, since it's rather large */
   dir_ent = obstack_alloc(&mem_pool, sizeof(struct dirent));
 
-  if ((dir = opendir("/proc")) == NULL)
+  if((dir = opendir("/proc")) == NULL) {
     return;
+  }
 
   /* Iterate through all the process entries (numeric) under /proc */
   while(readdir_r(dir, dir_ent, &dir_result) == 0 && dir_result) {
-
     /* Only look at this file if it's a proc id; that is, all numbers */
-    if(!is_pid(dir_result->d_name))
+    if(!is_pid(dir_result->d_name)) {
       continue;
+    }
 
     /* allocate container for storing process values */
     prs = obstack_alloc(&mem_pool, sizeof(struct procstat));
@@ -719,16 +747,17 @@ void OS_get_table()
     /* initialize the format string */
     obstack_printf(&mem_pool, "%s", get_string(STR_DEFAULT_FORMAT));
     obstack_1grow(&mem_pool, '\0');
-    format_str = (char *) obstack_finish(&mem_pool);
+    format_str = (char *)obstack_finish(&mem_pool);
 
     /* get process' uid/guid */
     get_user_info(dir_result->d_name, format_str, prs, &mem_pool);
 
     /* scrape /proc/${pid}/stat */
-    if (get_proc_stat(dir_result->d_name, format_str, prs, &mem_pool) == false) {
+    if(get_proc_stat(dir_result->d_name, format_str, prs, &mem_pool) == false) {
       /* did the pid directory go away mid flight? */
-      if (pid_exists(dir_result->d_name, &mem_pool) == false)
+      if(pid_exists(dir_result->d_name, &mem_pool) == false) {
         continue;
+      }
     }
 
     /* correct values (times) found in /proc/${pid}/stat */
@@ -755,13 +784,13 @@ void OS_get_table()
     /* extra Windows stuff */
     get_proc_winexename(dir_result->d_name, format_str, prs, &mem_pool);
     get_proc_winpid(dir_result->d_name, format_str, prs, &mem_pool);
-    
+
     /* calculate precent cpu & mem values */
     calc_prec(format_str, prs, &mem_pool);
 
     /* Go ahead and bless into a perl object */
     /* Linux.h defines const char* const* Fiels, but we cast it away, as bless_into_proc only understands char** */
-    bless_into_proc(format_str, (char**) field_names,
+    bless_into_proc(format_str, (char **)field_names,
                     prs->uid,
                     prs->gid,
                     prs->pid,

--- a/os/Cygwin.h
+++ b/os/Cygwin.h
@@ -1,0 +1,314 @@
+#define LENGTH_PCTCPU 10  /* Maximum percent cpu sufficient to hold 100000.00 or up to 1000 cpus  */
+/* Proc::ProcessTable functions */
+void ppt_warn(const char*, ...);
+void bless_into_proc(char* , char**, ...);
+
+/* it also gets used by init_static_vars at the way top of the file,
+ * I wanted init_static_vars to be at the way top close to the global vars */
+static char *read_file(const char *path, const char *extra_path, off_t *len,
+    struct obstack *mem_pool);
+
+struct procstat
+{
+  /* user/group id of the user running it */
+  int                   uid;
+  int                   gid;
+  /* values scraped from /proc/{$pid}/stat */
+  pid_t                 pid;
+  char                	comm[NAME_MAX];
+  char                	state_c;
+  int                 	ppid;
+  int                 	pgrp;
+  int                 	sid;
+  int                 	tty;
+  unsigned            	flags;
+  unsigned long       	minflt, cminflt, majflt, cmajflt;
+  unsigned long long  	utime, stime;
+  long long           	cutime, cstime;
+  long                	priority;
+  unsigned long long  	start_time;
+  unsigned long       	vsize;
+  long                	rss;
+  /* these are derived from above time values */
+  unsigned long long    time, ctime;
+  /* from above state_c but fixed up elsewhere */
+  const char           *state;
+  /* values scraped from /proc/{$pid}/status */
+  int                   euid, suid, fuid;
+  int                   egid, sgid, fgid;
+  /* cwd, cmdline & exec files; values allocated at the end of obstacks */
+  char                 *cwd;
+  char                 *cmndline;
+  char                 *cmdline;
+  int                   cmdline_len;
+  char                 *environ;
+  int                   environ_len;
+  char                 *exec;
+  /* other values */
+  char                  pctcpu[LENGTH_PCTCPU];    /* percent cpu, without '%' char */
+  char                  pctmem[sizeof("100.00")]; /* percent memory, without '%' char */
+  /* extra Windows stuff */
+  char                 *winexename;
+  int                   winpid;
+};
+
+
+enum state
+{
+    SLEEP,
+    RUN,
+    DEFUNCT,
+    STOP,
+    UWAIT,
+};
+
+
+/* strings, to make sure they get placed in read only memory,
+ * ditto for pointers to them and so we avoid relocations */
+static const char strings[] =
+{
+  /* process state */
+  "sleep\0"
+  "run\0"
+  "defunct\0"
+  "stop\0"
+  "uwait\0"
+  /* error messages */
+  "/proc unavailable\0"
+  "initialization failed\0"
+  /* fields */
+  "uid\0"
+  "gid\0"
+  "pid\0"
+  "fname\0"
+  "ppid\0"
+  "pgrp\0"
+  "sess\0"
+  "ttynum\0"
+  "flags\0"
+  "minflt\0"
+  "cminflt\0"
+  "majflt\0"
+  "cmajflt\0"
+  "utime\0"
+  "stime\0"
+  "cutime\0"
+  "cstime\0"
+  "priority\0"
+  "start\0"
+  "size\0"
+  "rss\0"
+  "time\0"
+  "ctime\0"
+  "state\0"
+  "euid\0"
+  "suid\0"
+  "fuid\0"
+  "egid\0"
+  "sgid\0"
+  "fgid\0"
+  "pctcpu\0"
+  "pctmem\0"
+  "cmndline\0"
+  "exec\0"
+  "cwd\0"
+  "cmdline\0"
+  "environ\0"
+  "winexename\0"
+  "winpid\0"
+  /* format string */
+  "IIISIIIILLLLLJJJJIJPLJJSIIIIIISSSSSAASI\0"
+};
+
+static const size_t strings_index[] =
+{
+  /* process status strings */
+    0, /*  6 sleep */
+    6, /*  4 run */
+   10, /*  8 defunct */
+   18, /*  5 stop */
+   23, /*  6 uwait */
+  /* error messages */
+   29, /* 18 /proc unavailable */
+   47, /* 22 initialization failed */
+  /* fields */
+   69, /*  4 uid */
+   73, /*  4 gid */
+   77, /*  4 pid */
+   81, /*  6 fname */
+   87, /*  5 ppid */
+   92, /*  5 pgrp */
+   97, /*  5 sess */
+  102, /*  7 ttynum */
+  109, /*  6 flags */
+  115, /*  7 minflt */
+  122, /*  8 cminflt */
+  130, /*  7 majflt */
+  137, /*  8 cmajflt */
+  145, /*  6 utime */
+  151, /*  6 stime */
+  157, /*  7 cutime */
+  164, /*  7 cstime */
+  171, /*  9 priority */
+  180, /*  6 start */
+  186, /*  5 size */
+  191, /*  4 rss */
+  195, /*  5 time */
+  200, /*  6 ctime */
+  206, /*  6 state */
+  212, /*  5 euid */
+  217, /*  5 suid */
+  222, /*  5 fuid */
+  227, /*  5 egid */
+  232, /*  5 sgid */
+  237, /*  5 fgid */
+  242, /*  7 pctcpu */
+  249, /*  7 pctmem */
+  256, /*  9 cmndline */
+  265, /*  5 exec */
+  270, /*  4 cwd */
+  274, /*  8 cmdline */
+  282, /*  8 environ */
+  290, /* 11 winexename */
+  301, /*  7 winpid */
+  /* default format string (pre lower casing) */
+  308
+};
+
+
+enum string_name {
+    /* NOTE: we start this enum at 10, so we can use still keep using the
+     * state enum, and have those correspond to the static strings */
+/* error messages */
+    STR_ERR_PROC_STATFS = 5,
+    STR_ERR_INIT,
+/* fields */
+    STR_FIELD_UID,
+    STR_FIELD_GID,
+    STR_FIELD_PID,
+    STR_FIELD_FNAME,
+    STR_FIELD_PPID,
+    STR_FIELD_PGRP,
+    STR_FIELD_SESS,
+    STR_FIELD_TTYNUM,
+    STR_FIELD_FLAGS,
+    STR_FIELD_MINFLT,
+    STR_FIELD_CMINFLT,
+    STR_FIELD_MAJFLT,
+    STR_FIELD_CMAJFLT,
+    STR_FIELD_UTIME,
+    STR_FIELD_STIME,
+    STR_FIELD_CUTIME,
+    STR_FIELD_CSTIME,
+    STR_FIELD_PRIORITY,
+    STR_FIELD_START,
+    STR_FIELD_SIZE,
+    STR_FIELD_RSS,
+    STR_FIELD_TIME,
+    STR_FIELD_CTIME,
+    STR_FIELD_STATE,
+    STR_FIELD_EUID,
+    STR_FIELD_SUID,
+    STR_FIELD_FUID,
+    STR_FIELD_EGID,
+    STR_FIELD_SGID,
+    STR_FIELD_FGID,
+    STR_FIELD_PCTCPU,
+    STR_FIELD_PCTMEM,
+    STR_FIELD_CMNDLINE,
+    STR_FIELD_EXEC,
+    STR_FIELD_CWD,
+    STR_FIELD_CMDLINE,
+    STR_FIELD_ENVIRON,
+    STR_FIELD_WINEXENAME,
+    STR_FIELD_WINPID,
+/* format string */
+    STR_DEFAULT_FORMAT
+};
+
+
+enum field
+{
+    F_UID,
+    F_GID,
+    F_PID,
+    F_FNAME,
+    F_PPID,
+    F_PGRP,
+    F_SESS,
+    F_TTYNUM,
+    F_FLAGS,
+    F_MINFLT,
+    F_CMINFLT,
+    F_MAJFLT,
+    F_CMAJFLT,
+    F_UTIME,
+    F_STIME,
+    F_CUTIME,
+    F_CSTIME,
+    F_PRIORITY,
+    F_START,
+    F_SIZE,
+    F_RSS,
+    F_TIME,
+    F_CTIME,
+    F_STATE,
+    F_EUID,
+    F_SUID,
+    F_FUID,
+    F_EGID,
+    F_SGID,
+    F_FGID,
+    F_PCTCPU,
+    F_PCTMEM,
+    F_CMNDLINE,
+    F_EXEC,
+    F_CWD,
+    F_CMDLINE,
+    F_ENVIRON,
+    F_WINEXENAME,
+    F_WINPID
+};
+
+static const char* const field_names[] =
+{
+    strings +   69, /*  4 uid */
+    strings +   73, /*  4 gid */
+    strings +   77, /*  4 pid */
+    strings +   81, /*  6 fname */
+    strings +   87, /*  5 ppid */
+    strings +   92, /*  5 pgrp */
+    strings +   97, /*  5 sess */
+    strings +  102, /*  7 ttynum */
+    strings +  109, /*  6 flags */
+    strings +  115, /*  7 minflt */
+    strings +  122, /*  8 cminflt */
+    strings +  130, /*  7 majflt */
+    strings +  137, /*  8 cmajflt */
+    strings +  145, /*  6 utime */
+    strings +  151, /*  6 stime */
+    strings +  157, /*  7 cutime */
+    strings +  164, /*  7 cstime */
+    strings +  171, /*  9 priority */
+    strings +  180, /*  6 start */
+    strings +  186, /*  5 size */
+    strings +  191, /*  4 rss */
+    strings +  195, /*  5 time */
+    strings +  200, /*  6 ctime */
+    strings +  206, /*  6 state */
+    strings +  212, /*  5 euid */
+    strings +  217, /*  5 suid */
+    strings +  222, /*  5 fuid */
+    strings +  227, /*  5 egid */
+    strings +  232, /*  5 sgid */
+    strings +  237, /*  5 fgid */
+    strings +  242, /*  7 pctcpu */
+    strings +  249, /*  7 pctmem */
+    strings +  256, /*  9 cmndline */
+    strings +  265, /*  5 exec */
+    strings +  270, /*  4 cwd */
+    strings +  274, /*  8 cmdline */
+    strings +  282, /*  8 environ */
+    strings +  290, /* 11 winexename */
+    strings +  301, /*  7 winpid */
+};

--- a/os/Linux.c
+++ b/os/Linux.c
@@ -363,39 +363,39 @@ static bool get_proc_stat(char *pid, char *format_str, struct procstat *prs,
 
   /* scrape the remaining values */
   result = sscanf(stat_cont,
-                  " %c" /*  state */
-                  " %d" /*  ppid */
-                  " %d" /*  pgrp */
-                  " %d" /*  sid */
-                  " %d" /*  tty */
-                  " %d" /*  tty_pgid (dummy) */
-                  " %u" /*  flags */
-                  " %lu" /* minflt */
-                  " %lu" /* cminflt */
-                  " %lu" /* majflt */
-                  " %lu" /* cmajflt */
-                  " %llu" /* utime */
-                  " %llu" /* stime */
-                  " %llu" /* cutime */
-                  " %lld" /* cstime */
-                  " %ld" /* priority */
-                  " %ld" /* nice (dummy) */
-                  " %ld" /* num_threads (dummy) */
-                  " %d" /* itrealvalue (dummy) */
-                  " %llu" /* start_time */
-                  " %lu" /* vsize */
-                  " %ld" /* rss */
-                  " %ld" /* rsslim */
-                  " %lu" /* start_code (dummy) */
-                  " %lu" /* end_code (dummy) */
-                  " %lu" /* start_stack (dummy) */
-                  " %lu" /* esp (dummy) */
-                  " %lu" /* eip (dummy) */
-                  " %lu" /* pending (dummy) */
-                  " %lu" /* blocked (dummy) */
-                  " %lu" /* sigign (dummy) */
-                  " %lu" /* sigcatch (dummy) */
-                  " %lu" /* wchan (obsolete) */
+                  " %c"                        /*  state */
+                  " %d"                        /*  ppid */
+                  " %d"                        /*  pgrp */
+                  " %d"                        /*  sid */
+                  " %d"                        /*  tty */
+                  " %d"                        /*  tty_pgid (dummy) */
+                  " %u"                        /*  flags */
+                  " %lu"                       /* minflt */
+                  " %lu"                       /* cminflt */
+                  " %lu"                       /* majflt */
+                  " %lu"                       /* cmajflt */
+                  " %llu"                      /* utime */
+                  " %llu"                      /* stime */
+                  " %llu"                      /* cutime */
+                  " %lld"                      /* cstime */
+                  " %ld"                       /* priority */
+                  " %ld"                       /* nice (dummy) */
+                  " %ld"                       /* num_threads (dummy) */
+                  " %d"                        /* itrealvalue (dummy) */
+                  " %llu"                      /* start_time */
+                  " %lu"                       /* vsize */
+                  " %ld"                       /* rss */
+                  " %ld"                       /* rsslim */
+                  " %lu"                       /* start_code (dummy) */
+                  " %lu"                       /* end_code (dummy) */
+                  " %lu"                       /* start_stack (dummy) */
+                  " %lu"                       /* esp (dummy) */
+                  " %lu"                       /* eip (dummy) */
+                  " %lu"                       /* pending (dummy) */
+                  " %lu"                       /* blocked (dummy) */
+                  " %lu"                       /* sigign (dummy) */
+                  " %lu"                       /* sigcatch (dummy) */
+                  " %lu"                       /* wchan (obsolete) */
                   ,
                   &prs->state_c,               /* %c */
                   &prs->ppid, &prs->pgrp,      /* %d %d */

--- a/t/bugfix-106571_odd_process_name.t
+++ b/t/bugfix-106571_odd_process_name.t
@@ -3,7 +3,7 @@ use Test::More;
 use Data::Dumper;
 
 BEGIN {
-  if ($^O eq 'cygwin') {
+  if ($^O eq 'cygwin_') {
     plan skip_all => 'Test irrelevant on cygwin';
   }
 

--- a/t/bugfix-106571_odd_process_name.t
+++ b/t/bugfix-106571_odd_process_name.t
@@ -3,10 +3,6 @@ use Test::More;
 use Data::Dumper;
 
 BEGIN {
-  if ($^O eq 'cygwin_') {
-    plan skip_all => 'Test irrelevant on cygwin';
-  }
-
   use_ok('Proc::ProcessTable');
 }
 

--- a/t/bugfix-51470_cmndline_mod_error.t
+++ b/t/bugfix-51470_cmndline_mod_error.t
@@ -3,7 +3,7 @@ use Test::More;
 use Data::Dumper;
 
 BEGIN {
-  if ($^O eq 'cygwin') {
+  if ($^O eq 'cygwin_') {
     plan skip_all => 'Test irrelevant on cygwin';
   }
 

--- a/t/bugfix-51470_cmndline_mod_error.t
+++ b/t/bugfix-51470_cmndline_mod_error.t
@@ -3,10 +3,6 @@ use Test::More;
 use Data::Dumper;
 
 BEGIN {
-  if ($^O eq 'cygwin_') {
-    plan skip_all => 'Test irrelevant on cygwin';
-  }
-
   use_ok('Proc::ProcessTable');
 }
 

--- a/t/bugfix-61946_odd_process_name.t
+++ b/t/bugfix-61946_odd_process_name.t
@@ -3,7 +3,7 @@ use Test::More;
 use Data::Dumper;
 
 BEGIN {
-  if ( $^O eq 'cygwin' ) {
+  if ( $^O eq 'cygwin_' ) {
     plan skip_all => 'Test irrelevant on cygwin';
   }
 

--- a/t/bugfix-61946_odd_process_name.t
+++ b/t/bugfix-61946_odd_process_name.t
@@ -3,10 +3,6 @@ use Test::More;
 use Data::Dumper;
 
 BEGIN {
-  if ( $^O eq 'cygwin_' ) {
-    plan skip_all => 'Test irrelevant on cygwin';
-  }
-
   use_ok('Proc::ProcessTable');
 }
 


### PR DESCRIPTION
I was quite surprised: I got a mail with a patch for a better cygwin implementation, derived from linux. And even the spelling mistakes are corrected! How cool is that, thanks a lot. I mangled the `Linux.c` and `Cygwin.c` with [uncrustify](https://github.com/uncrustify/uncrustify) to compare and align them. Everything I deemed better in `Cygwin.c` I also added to `Linux.c`.

Thanks, again, Achim.

Here is the original email text (relevant parts only) for reference:

> based on the Linux implementation I've re-implemented the handling for Cygwin 
> as it offers a /proc filesystem since quite some time and the old 
> implementation lacked many fields that other modules expect to be usable.  
> This requires inclusion of an obstack implementation since Cygwin is not glibc 
> based.  I've used the sources from musl-obstack (which in turn uses sources 
> from gcc).