### PR TITLE
do not try to scan /dev/.lxd-mounts

### DIFF
--- a/lib/Proc/ProcessTable.pm
+++ b/lib/Proc/ProcessTable.pm
@@ -155,7 +155,7 @@ sub _get_tty_list
   return unless -d "/dev";
   find({ wanted => 
        sub{
-     $File::Find::prune = 1 if -d $_ && ( ! -x $_ || $_ eq "/dev/.lxc");
+     $File::Find::prune = 1 if -d $_ && ( ! -x $_ || $_ eq "/dev/.lxc" || $_ eq "/dev/.lxd-mounts");
      my($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size,
         $atime,$mtime,$ctime,$blksize,$blocks) = stat($File::Find::name);
      $Proc::ProcessTable::TTYDEVS{$rdev} = $File::Find::name


### PR DESCRIPTION
When Proc::ProcTable is used on system running under LXD (in my case 5.0.2-2+b2) it produces error output:
```
Can't opendir(/dev/.lxd-mounts): Permission denied
 at /usr/lib/x86_64-linux-gnu/perl5/5.32/Proc/ProcessTable.pm line 163.
```
So I'm proposing same fix as is already in place for LXC.